### PR TITLE
fix: agent desync

### DIFF
--- a/src/Module.Server/Common/CrpgSpawningBehaviorBase.cs
+++ b/src/Module.Server/Common/CrpgSpawningBehaviorBase.cs
@@ -135,7 +135,7 @@ private int totalNumberOfBots = 800;
 
             p++;
             BasicCultureObject teamCulture = missionPeer.Team == Mission.AttackerTeam ? cultureTeam1 : cultureTeam2;
-            var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>($"crpg_class_division_{p}");
+            var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>($"crpg_captain_division_{p}");
             // var character = CreateCharacter(crpgPeer.User.Character, _constants);
             var characterSkills = CrpgCharacterBuilder.CreateCharacterSkills(crpgPeer.User!.Character.Characteristics);
             var characterXml = peerClass.HeroCharacter;
@@ -241,7 +241,7 @@ private int totalNumberOfBots = 800;
 
                 for (int i = 0; i < peerNumberOfBots; i++)
                 {
-                    SpawnBotAgent(peerClass.StringId, agent.Team, missionPeer, p);
+                    SpawnBotAgent($"crpg_captain_bot_division_{p}", agent.Team, missionPeer, p);
                 }
             }
 
@@ -295,7 +295,7 @@ private int totalNumberOfBots = 800;
             if (crpgPeer != null && crpgPeer?.User != null)
             {
                 Equipment characterEquipment = CrpgCharacterBuilder.CreateCharacterEquipment(crpgPeer.User.Character.EquippedItems);
-                MultiplayerClassDivisions.MPHeroClass? peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>($"crpg_class_division_{p}");
+                MultiplayerClassDivisions.MPHeroClass? peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>($"crpg_captain_bot_division_{p}");
                 CharacterSkills characterSkills = CrpgCharacterBuilder.CreateCharacterSkills(crpgPeer.User!.Character.Characteristics);
                 BasicCharacterObject? characterXml = peerClass.HeroCharacter;
                 CrpgBattleAgentOrigin troopOrigin = new CrpgBattleAgentOrigin(characterXml, characterSkills);

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -271,12 +271,14 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 agent.Origin = new CrpgBattleAgentOrigin(agent.Origin?.Troop, mbSkills);
                 InitializeAgentStats(agent, agent.SpawnEquipment, props, null!);
             }
-            else if (agentCharacterId.StartsWith("crpg_character"))
+            else if (agentCharacterId.StartsWith("crpg_captain_bot"))
             {
+                string[] parts = agentCharacterId.Split('_');
+                string id = parts.Last();
                 var crpgNetworkPeers = GameNetwork.NetworkPeers.Where(p =>
                     p.GetComponent<CrpgPeer>() != null);
                 var ownerNetworkPeer =
-                    crpgNetworkPeers.FirstOrDefault(p => p.ControlledAgent?.Character.StringId.Contains(agentCharacterId) ?? false);
+                    crpgNetworkPeers.FirstOrDefault(p => p.ControlledAgent?.Character.StringId.Contains($"crpg_captain_{id}") ?? false);
                 if (ownerNetworkPeer?.GetComponent<CrpgPeer>()?.User != null && agent.Origin is not CrpgBattleAgentOrigin)
                 {
                     var characteristics = ownerNetworkPeer.GetComponent<CrpgPeer>().User!.Character.Characteristics;
@@ -284,14 +286,13 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                     agent.Origin = new CrpgBattleAgentOrigin(agent.Origin?.Troop, mbSkills);
                     InitializeAgentStats(agent, agent.SpawnEquipment, props, null!);
                 }
-
             }
         }/*
             else if (agent.Character.StringId.StartsWith("crpg_h")
             {
-                agent.Origin = new CrpgBattleAgentOrigin(agent.Origin?.Troop, crpgComponent._mbSkills);
-                InitializeAgentStats(agent, agent.SpawnEquipment, props, null!);
-            }*/
+            agent.Origin = new CrpgBattleAgentOrigin(agent.Origin?.Troop, crpgComponent._mbSkills);
+            InitializeAgentStats(agent, agent.SpawnEquipment, props, null!);
+        }*/
 
 
         MissionEquipment equipment = agent.Equipment;

--- a/src/Module.Server/Modes/TrainingGround/CrpgTrainingGroundSpawningBehavior.cs
+++ b/src/Module.Server/Modes/TrainingGround/CrpgTrainingGroundSpawningBehavior.cs
@@ -79,7 +79,7 @@ internal class CrpgTrainingGroundSpawningBehavior : CrpgSpawningBehaviorBase
         controlledAgent.FadeOut(true, true);
 
         BasicCultureObject teamCulture = missionPeer.Team == Mission.AttackerTeam ? cultureTeam1 : cultureTeam2;
-        var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>("crpg_class_division");
+        var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>("crpg_captain_division_1");
         var characterSkills = CrpgCharacterBuilder.CreateCharacterSkills(crpgPeer.User!.Character.Characteristics);
         var characterXml = peerClass.HeroCharacter;
 

--- a/src/Module.Server/ModuleData/crpg_captain_characters.xml
+++ b/src/Module.Server/ModuleData/crpg_captain_characters.xml
@@ -1,2004 +1,4004 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MPCharacters>
 <!-- forgive me for i have sinned-->
-<NPCCharacter id="crpg_character_1" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_1" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_2" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_2" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_3" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_3" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_4" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_4" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_5" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_5" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_6" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_6" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_7" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_7" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_8" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_8" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_9" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_9" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_10" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_10" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_11" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_11" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_12" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_12" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_13" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_13" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_14" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_14" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_15" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_15" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_16" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_16" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_17" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_17" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_18" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_18" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_19" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_19" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_20" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_20" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_21" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_21" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_22" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_22" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_23" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_23" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_24" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_24" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_25" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_25" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_26" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_26" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_27" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_27" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_28" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_28" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_29" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_29" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_30" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_30" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_31" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_31" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_32" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_32" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_33" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_33" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_34" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_34" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_35" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_35" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_36" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_36" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_37" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_37" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_38" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_38" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_39" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_39" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_40" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_40" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_41" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_41" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_42" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_42" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_43" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_43" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_44" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_44" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_45" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_45" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_46" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_46" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_47" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_47" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_48" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_48" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_49" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_49" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_50" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_50" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_51" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_51" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_52" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_52" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_53" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_53" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_54" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_54" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_55" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_55" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_56" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_56" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_57" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_57" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_58" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_58" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_59" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_59" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_60" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_60" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_61" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_61" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_62" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_62" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_63" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_63" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_64" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_64" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_65" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_65" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_66" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_66" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_67" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_67" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_68" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_68" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_69" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_69" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_70" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_70" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_71" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_71" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_72" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_72" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_73" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_73" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_74" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_74" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_75" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_75" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_76" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_76" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_77" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_77" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_78" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_78" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_79" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_79" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_80" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_80" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_81" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_81" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_82" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_82" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_83" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_83" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_84" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_84" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_85" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_85" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_86" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_86" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_87" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_87" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_88" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_88" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_89" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_89" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_90" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_90" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_91" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_91" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_92" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_92" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_93" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_93" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_94" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_94" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_95" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_95" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_96" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_96" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_97" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_97" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_98" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_98" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_99" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_99" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_100" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_100" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_101" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_101" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_102" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_102" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_103" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_103" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_104" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_104" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_105" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_105" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_106" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_106" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_107" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_107" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_108" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_108" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_109" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_109" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_110" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_110" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_111" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_111" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_112" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_112" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_113" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_113" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_114" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_114" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_115" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_115" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_116" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_116" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_117" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_117" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_118" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_118" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_119" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_119" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_120" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_120" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_121" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_121" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_122" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_122" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_123" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_123" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_124" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_124" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_125" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_125" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_126" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_126" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_127" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_127" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_128" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_128" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_129" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_129" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_130" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_130" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_131" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_131" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_132" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_132" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_133" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_133" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_134" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_134" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_135" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_135" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_136" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_136" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_137" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_137" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_138" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_138" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_139" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_139" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_140" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_140" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_141" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_141" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_142" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_142" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_143" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_143" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_144" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_144" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_145" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_145" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_146" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_146" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_147" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_147" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_148" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_148" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_149" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_149" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_150" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_150" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_151" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_151" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_152" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_152" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_153" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_153" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_154" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_154" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_155" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_155" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_156" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_156" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_157" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_157" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_158" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_158" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_159" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_159" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_160" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_160" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_161" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_161" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_162" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_162" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_163" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_163" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_164" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_164" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_165" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_165" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_166" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_166" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_167" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_167" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_168" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_168" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_169" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_169" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_170" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_170" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_171" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_171" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_172" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_172" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_173" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_173" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_174" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_174" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_175" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_175" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_176" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_176" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_177" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_177" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_178" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_178" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_179" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_179" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_180" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_180" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_181" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_181" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_182" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_182" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_183" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_183" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_184" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_184" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_185" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_185" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_186" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_186" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_187" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_187" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_188" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_188" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_189" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_189" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_190" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_190" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_191" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_191" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_192" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_192" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_193" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_193" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_194" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_194" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_195" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_195" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_196" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_196" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_197" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_197" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_198" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_198" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_199" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_199" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_200" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_200" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_201" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_201" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_202" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_202" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_203" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_203" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_204" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_204" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_205" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_205" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_206" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_206" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_207" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_207" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_208" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_208" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_209" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_209" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_210" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_210" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_211" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_211" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_212" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_212" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_213" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_213" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_214" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_214" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_215" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_215" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_216" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_216" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_217" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_217" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_218" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_218" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_219" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_219" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_220" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_220" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_221" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_221" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_222" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_222" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_223" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_223" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_224" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_224" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_225" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_225" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_226" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_226" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_227" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_227" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_228" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_228" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_229" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_229" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_230" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_230" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_231" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_231" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_232" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_232" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_233" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_233" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_234" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_234" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_235" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_235" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_236" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_236" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_237" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_237" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_238" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_238" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_239" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_239" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_240" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_240" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_241" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_241" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_242" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_242" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_243" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_243" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_244" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_244" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_245" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_245" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_246" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_246" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_247" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_247" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_248" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_248" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_249" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_249" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_250" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_250" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_251" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_251" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_252" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_252" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_253" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_253" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_254" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_254" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_255" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_255" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_256" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_256" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_257" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_257" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_258" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_258" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_259" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_259" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_260" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_260" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_261" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_261" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_262" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_262" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_263" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_263" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_264" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_264" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_265" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_265" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_266" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_266" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_267" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_267" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_268" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_268" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_269" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_269" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_270" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_270" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_271" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_271" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_272" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_272" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_273" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_273" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_274" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_274" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_275" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_275" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_276" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_276" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_277" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_277" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_278" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_278" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_279" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_279" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_280" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_280" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_281" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_281" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_282" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_282" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_283" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_283" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_284" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_284" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_285" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_285" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_286" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_286" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_287" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_287" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_288" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_288" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_289" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_289" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_290" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_290" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_291" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_291" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_292" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_292" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_293" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_293" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_294" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_294" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_295" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_295" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_296" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_296" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_297" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_297" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_298" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_298" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_299" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_299" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_300" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_300" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_301" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_301" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_302" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_302" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_303" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_303" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_304" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_304" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_305" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_305" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_306" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_306" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_307" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_307" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_308" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_308" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_309" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_309" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_310" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_310" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_311" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_311" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_312" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_312" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_313" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_313" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_314" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_314" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_315" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_315" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_316" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_316" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_317" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_317" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_318" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_318" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_319" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_319" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_320" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_320" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_321" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_321" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_322" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_322" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_323" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_323" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_324" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_324" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_325" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_325" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_326" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_326" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_327" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_327" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_328" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_328" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_329" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_329" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_330" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_330" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_331" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_331" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_332" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_332" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_333" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_333" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_334" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_334" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_335" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_335" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_336" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_336" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_337" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_337" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_338" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_338" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_339" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_339" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_340" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_340" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_341" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_341" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_342" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_342" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_343" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_343" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_344" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_344" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_345" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_345" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_346" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_346" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_347" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_347" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_348" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_348" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_349" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_349" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_350" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_350" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_351" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_351" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_352" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_352" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_353" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_353" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_354" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_354" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_355" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_355" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_356" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_356" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_357" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_357" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_358" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_358" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_359" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_359" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_360" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_360" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_361" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_361" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_362" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_362" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_363" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_363" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_364" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_364" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_365" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_365" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_366" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_366" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_367" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_367" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_368" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_368" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_369" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_369" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_370" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_370" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_371" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_371" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_372" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_372" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_373" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_373" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_374" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_374" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_375" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_375" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_376" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_376" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_377" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_377" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_378" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_378" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_379" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_379" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_380" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_380" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_381" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_381" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_382" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_382" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_383" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_383" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_384" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_384" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_385" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_385" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_386" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_386" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_387" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_387" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_388" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_388" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_389" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_389" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_390" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_390" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_391" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_391" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_392" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_392" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_393" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_393" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_394" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_394" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_395" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_395" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_396" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_396" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_397" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_397" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_398" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_398" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_399" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_399" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
 </NPCCharacter>
-<NPCCharacter id="crpg_character_400" name="{=}Captain Bot">
+<NPCCharacter id="crpg_captain_400" name="{=}Captain">
     <face>
       <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
     </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_1" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_2" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_3" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_4" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_5" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_6" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_7" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_8" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_9" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_10" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_11" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_12" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_13" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_14" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_15" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_16" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_17" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_18" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_19" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_20" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_21" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_22" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_23" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_24" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_25" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_26" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_27" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_28" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_29" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_30" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_31" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_32" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_33" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_34" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_35" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_36" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_37" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_38" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_39" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_40" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_41" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_42" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_43" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_44" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_45" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_46" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_47" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_48" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_49" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_50" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_51" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_52" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_53" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_54" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_55" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_56" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_57" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_58" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_59" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_60" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_61" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_62" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_63" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_64" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_65" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_66" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_67" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_68" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_69" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_70" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_71" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_72" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_73" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_74" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_75" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_76" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_77" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_78" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_79" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_80" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_81" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_82" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_83" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_84" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_85" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_86" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_87" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_88" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_89" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_90" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_91" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_92" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_93" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_94" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_95" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_96" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_97" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_98" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_99" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_100" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_101" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_102" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_103" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_104" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_105" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_106" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_107" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_108" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_109" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_110" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_111" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_112" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_113" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_114" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_115" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_116" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_117" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_118" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_119" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_120" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_121" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_122" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_123" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_124" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_125" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_126" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_127" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_128" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_129" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_130" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_131" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_132" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_133" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_134" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_135" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_136" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_137" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_138" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_139" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_140" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_141" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_142" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_143" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_144" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_145" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_146" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_147" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_148" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_149" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_150" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_151" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_152" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_153" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_154" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_155" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_156" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_157" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_158" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_159" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_160" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_161" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_162" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_163" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_164" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_165" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_166" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_167" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_168" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_169" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_170" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_171" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_172" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_173" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_174" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_175" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_176" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_177" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_178" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_179" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_180" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_181" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_182" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_183" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_184" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_185" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_186" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_187" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_188" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_189" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_190" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_191" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_192" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_193" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_194" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_195" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_196" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_197" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_198" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_199" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_200" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_201" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_202" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_203" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_204" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_205" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_206" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_207" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_208" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_209" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_210" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_211" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_212" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_213" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_214" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_215" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_216" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_217" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_218" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_219" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_220" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_221" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_222" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_223" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_224" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_225" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_226" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_227" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_228" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_229" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_230" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_231" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_232" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_233" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_234" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_235" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_236" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_237" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_238" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_239" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_240" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_241" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_242" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_243" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_244" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_245" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_246" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_247" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_248" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_249" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_250" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_251" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_252" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_253" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_254" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_255" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_256" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_257" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_258" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_259" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_260" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_261" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_262" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_263" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_264" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_265" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_266" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_267" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_268" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_269" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_270" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_271" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_272" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_273" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_274" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_275" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_276" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_277" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_278" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_279" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_280" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_281" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_282" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_283" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_284" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_285" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_286" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_287" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_288" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_289" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_290" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_291" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_292" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_293" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_294" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_295" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_296" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_297" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_298" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_299" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_300" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_301" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_302" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_303" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_304" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_305" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_306" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_307" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_308" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_309" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_310" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_311" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_312" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_313" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_314" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_315" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_316" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_317" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_318" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_319" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_320" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_321" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_322" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_323" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_324" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_325" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_326" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_327" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_328" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_329" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_330" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_331" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_332" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_333" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_334" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_335" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_336" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_337" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_338" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_339" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_340" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_341" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_342" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_343" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_344" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_345" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_346" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_347" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_348" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_349" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_350" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_351" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_352" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_353" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_354" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_355" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_356" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_357" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_358" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_359" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_360" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_361" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_362" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_363" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_364" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_365" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_366" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_367" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_368" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_369" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_370" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_371" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_372" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_373" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_374" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_375" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_376" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_377" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_378" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_379" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_380" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_381" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_382" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_383" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_384" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_385" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_386" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_387" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_388" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_389" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_390" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_391" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_392" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_393" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_394" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_395" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_396" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_397" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_398" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_399" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
+</NPCCharacter>
+<NPCCharacter id="crpg_captain_bot_400" name="{=}Captain Bot">
+  <face>
+    <BodyProperties version="4" age="23" weight="0.3333" build="0" key="00000C07000000010011111211151111000701000010000000111011000101000000500202111110000000000000000000000000000000000000000000A00000" />
+  </face>
 </NPCCharacter>
 </MPCharacters>

--- a/src/Module.Server/ModuleData/crpg_captain_class_divisions.xml
+++ b/src/Module.Server/ModuleData/crpg_captain_class_divisions.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- have mercy on my soul , THEY made me do this... -->
 <MPClassDivisions>
-<MPClassDivision id="crpg_class_division_1"
-                   hero="crpg_character_1"
-                   troop="crpg_character_1"
+<MPClassDivision id="crpg_captain_division_1"
+                   hero="crpg_captain_1"
+                   troop="crpg_captain_1"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -24,9 +24,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_2"
-                   hero="crpg_character_2"
-                   troop="crpg_character_2"
+<MPClassDivision id="crpg_captain_division_2"
+                   hero="crpg_captain_2"
+                   troop="crpg_captain_2"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -47,9 +47,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_3"
-                   hero="crpg_character_3"
-                   troop="crpg_character_3"
+<MPClassDivision id="crpg_captain_division_3"
+                   hero="crpg_captain_3"
+                   troop="crpg_captain_3"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -70,9 +70,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_4"
-                   hero="crpg_character_4"
-                   troop="crpg_character_4"
+<MPClassDivision id="crpg_captain_division_4"
+                   hero="crpg_captain_4"
+                   troop="crpg_captain_4"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -93,9 +93,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_5"
-                   hero="crpg_character_5"
-                   troop="crpg_character_5"
+<MPClassDivision id="crpg_captain_division_5"
+                   hero="crpg_captain_5"
+                   troop="crpg_captain_5"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -116,9 +116,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_6"
-                   hero="crpg_character_6"
-                   troop="crpg_character_6"
+<MPClassDivision id="crpg_captain_division_6"
+                   hero="crpg_captain_6"
+                   troop="crpg_captain_6"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -139,9 +139,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_7"
-                   hero="crpg_character_7"
-                   troop="crpg_character_7"
+<MPClassDivision id="crpg_captain_division_7"
+                   hero="crpg_captain_7"
+                   troop="crpg_captain_7"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -162,9 +162,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_8"
-                   hero="crpg_character_8"
-                   troop="crpg_character_8"
+<MPClassDivision id="crpg_captain_division_8"
+                   hero="crpg_captain_8"
+                   troop="crpg_captain_8"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -185,9 +185,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_9"
-                   hero="crpg_character_9"
-                   troop="crpg_character_9"
+<MPClassDivision id="crpg_captain_division_9"
+                   hero="crpg_captain_9"
+                   troop="crpg_captain_9"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -208,9 +208,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_10"
-                   hero="crpg_character_10"
-                   troop="crpg_character_10"
+<MPClassDivision id="crpg_captain_division_10"
+                   hero="crpg_captain_10"
+                   troop="crpg_captain_10"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -231,9 +231,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_11"
-                   hero="crpg_character_11"
-                   troop="crpg_character_11"
+<MPClassDivision id="crpg_captain_division_11"
+                   hero="crpg_captain_11"
+                   troop="crpg_captain_11"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -254,9 +254,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_12"
-                   hero="crpg_character_12"
-                   troop="crpg_character_12"
+<MPClassDivision id="crpg_captain_division_12"
+                   hero="crpg_captain_12"
+                   troop="crpg_captain_12"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -277,9 +277,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_13"
-                   hero="crpg_character_13"
-                   troop="crpg_character_13"
+<MPClassDivision id="crpg_captain_division_13"
+                   hero="crpg_captain_13"
+                   troop="crpg_captain_13"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -300,9 +300,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_14"
-                   hero="crpg_character_14"
-                   troop="crpg_character_14"
+<MPClassDivision id="crpg_captain_division_14"
+                   hero="crpg_captain_14"
+                   troop="crpg_captain_14"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -323,9 +323,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_15"
-                   hero="crpg_character_15"
-                   troop="crpg_character_15"
+<MPClassDivision id="crpg_captain_division_15"
+                   hero="crpg_captain_15"
+                   troop="crpg_captain_15"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -346,9 +346,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_16"
-                   hero="crpg_character_16"
-                   troop="crpg_character_16"
+<MPClassDivision id="crpg_captain_division_16"
+                   hero="crpg_captain_16"
+                   troop="crpg_captain_16"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -369,9 +369,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_17"
-                   hero="crpg_character_17"
-                   troop="crpg_character_17"
+<MPClassDivision id="crpg_captain_division_17"
+                   hero="crpg_captain_17"
+                   troop="crpg_captain_17"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -392,9 +392,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_18"
-                   hero="crpg_character_18"
-                   troop="crpg_character_18"
+<MPClassDivision id="crpg_captain_division_18"
+                   hero="crpg_captain_18"
+                   troop="crpg_captain_18"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -415,9 +415,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_19"
-                   hero="crpg_character_19"
-                   troop="crpg_character_19"
+<MPClassDivision id="crpg_captain_division_19"
+                   hero="crpg_captain_19"
+                   troop="crpg_captain_19"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -438,9 +438,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_20"
-                   hero="crpg_character_20"
-                   troop="crpg_character_20"
+<MPClassDivision id="crpg_captain_division_20"
+                   hero="crpg_captain_20"
+                   troop="crpg_captain_20"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -461,9 +461,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_21"
-                   hero="crpg_character_21"
-                   troop="crpg_character_21"
+<MPClassDivision id="crpg_captain_division_21"
+                   hero="crpg_captain_21"
+                   troop="crpg_captain_21"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -484,9 +484,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_22"
-                   hero="crpg_character_22"
-                   troop="crpg_character_22"
+<MPClassDivision id="crpg_captain_division_22"
+                   hero="crpg_captain_22"
+                   troop="crpg_captain_22"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -507,9 +507,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_23"
-                   hero="crpg_character_23"
-                   troop="crpg_character_23"
+<MPClassDivision id="crpg_captain_division_23"
+                   hero="crpg_captain_23"
+                   troop="crpg_captain_23"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -530,9 +530,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_24"
-                   hero="crpg_character_24"
-                   troop="crpg_character_24"
+<MPClassDivision id="crpg_captain_division_24"
+                   hero="crpg_captain_24"
+                   troop="crpg_captain_24"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -553,9 +553,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_25"
-                   hero="crpg_character_25"
-                   troop="crpg_character_25"
+<MPClassDivision id="crpg_captain_division_25"
+                   hero="crpg_captain_25"
+                   troop="crpg_captain_25"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -576,9 +576,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_26"
-                   hero="crpg_character_26"
-                   troop="crpg_character_26"
+<MPClassDivision id="crpg_captain_division_26"
+                   hero="crpg_captain_26"
+                   troop="crpg_captain_26"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -599,9 +599,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_27"
-                   hero="crpg_character_27"
-                   troop="crpg_character_27"
+<MPClassDivision id="crpg_captain_division_27"
+                   hero="crpg_captain_27"
+                   troop="crpg_captain_27"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -622,9 +622,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_28"
-                   hero="crpg_character_28"
-                   troop="crpg_character_28"
+<MPClassDivision id="crpg_captain_division_28"
+                   hero="crpg_captain_28"
+                   troop="crpg_captain_28"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -645,9 +645,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_29"
-                   hero="crpg_character_29"
-                   troop="crpg_character_29"
+<MPClassDivision id="crpg_captain_division_29"
+                   hero="crpg_captain_29"
+                   troop="crpg_captain_29"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -668,9 +668,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_30"
-                   hero="crpg_character_30"
-                   troop="crpg_character_30"
+<MPClassDivision id="crpg_captain_division_30"
+                   hero="crpg_captain_30"
+                   troop="crpg_captain_30"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -691,9 +691,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_31"
-                   hero="crpg_character_31"
-                   troop="crpg_character_31"
+<MPClassDivision id="crpg_captain_division_31"
+                   hero="crpg_captain_31"
+                   troop="crpg_captain_31"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -714,9 +714,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_32"
-                   hero="crpg_character_32"
-                   troop="crpg_character_32"
+<MPClassDivision id="crpg_captain_division_32"
+                   hero="crpg_captain_32"
+                   troop="crpg_captain_32"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -737,9 +737,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_33"
-                   hero="crpg_character_33"
-                   troop="crpg_character_33"
+<MPClassDivision id="crpg_captain_division_33"
+                   hero="crpg_captain_33"
+                   troop="crpg_captain_33"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -760,9 +760,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_34"
-                   hero="crpg_character_34"
-                   troop="crpg_character_34"
+<MPClassDivision id="crpg_captain_division_34"
+                   hero="crpg_captain_34"
+                   troop="crpg_captain_34"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -783,9 +783,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_35"
-                   hero="crpg_character_35"
-                   troop="crpg_character_35"
+<MPClassDivision id="crpg_captain_division_35"
+                   hero="crpg_captain_35"
+                   troop="crpg_captain_35"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -806,9 +806,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_36"
-                   hero="crpg_character_36"
-                   troop="crpg_character_36"
+<MPClassDivision id="crpg_captain_division_36"
+                   hero="crpg_captain_36"
+                   troop="crpg_captain_36"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -829,9 +829,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_37"
-                   hero="crpg_character_37"
-                   troop="crpg_character_37"
+<MPClassDivision id="crpg_captain_division_37"
+                   hero="crpg_captain_37"
+                   troop="crpg_captain_37"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -852,9 +852,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_38"
-                   hero="crpg_character_38"
-                   troop="crpg_character_38"
+<MPClassDivision id="crpg_captain_division_38"
+                   hero="crpg_captain_38"
+                   troop="crpg_captain_38"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -875,9 +875,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_39"
-                   hero="crpg_character_39"
-                   troop="crpg_character_39"
+<MPClassDivision id="crpg_captain_division_39"
+                   hero="crpg_captain_39"
+                   troop="crpg_captain_39"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -898,9 +898,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_40"
-                   hero="crpg_character_40"
-                   troop="crpg_character_40"
+<MPClassDivision id="crpg_captain_division_40"
+                   hero="crpg_captain_40"
+                   troop="crpg_captain_40"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -921,9 +921,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_41"
-                   hero="crpg_character_41"
-                   troop="crpg_character_41"
+<MPClassDivision id="crpg_captain_division_41"
+                   hero="crpg_captain_41"
+                   troop="crpg_captain_41"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -944,9 +944,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_42"
-                   hero="crpg_character_42"
-                   troop="crpg_character_42"
+<MPClassDivision id="crpg_captain_division_42"
+                   hero="crpg_captain_42"
+                   troop="crpg_captain_42"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -967,9 +967,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_43"
-                   hero="crpg_character_43"
-                   troop="crpg_character_43"
+<MPClassDivision id="crpg_captain_division_43"
+                   hero="crpg_captain_43"
+                   troop="crpg_captain_43"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -990,9 +990,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_44"
-                   hero="crpg_character_44"
-                   troop="crpg_character_44"
+<MPClassDivision id="crpg_captain_division_44"
+                   hero="crpg_captain_44"
+                   troop="crpg_captain_44"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1013,9 +1013,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_45"
-                   hero="crpg_character_45"
-                   troop="crpg_character_45"
+<MPClassDivision id="crpg_captain_division_45"
+                   hero="crpg_captain_45"
+                   troop="crpg_captain_45"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1036,9 +1036,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_46"
-                   hero="crpg_character_46"
-                   troop="crpg_character_46"
+<MPClassDivision id="crpg_captain_division_46"
+                   hero="crpg_captain_46"
+                   troop="crpg_captain_46"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1059,9 +1059,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_47"
-                   hero="crpg_character_47"
-                   troop="crpg_character_47"
+<MPClassDivision id="crpg_captain_division_47"
+                   hero="crpg_captain_47"
+                   troop="crpg_captain_47"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1082,9 +1082,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_48"
-                   hero="crpg_character_48"
-                   troop="crpg_character_48"
+<MPClassDivision id="crpg_captain_division_48"
+                   hero="crpg_captain_48"
+                   troop="crpg_captain_48"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1105,9 +1105,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_49"
-                   hero="crpg_character_49"
-                   troop="crpg_character_49"
+<MPClassDivision id="crpg_captain_division_49"
+                   hero="crpg_captain_49"
+                   troop="crpg_captain_49"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1128,9 +1128,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_50"
-                   hero="crpg_character_50"
-                   troop="crpg_character_50"
+<MPClassDivision id="crpg_captain_division_50"
+                   hero="crpg_captain_50"
+                   troop="crpg_captain_50"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1151,9 +1151,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_51"
-                   hero="crpg_character_51"
-                   troop="crpg_character_51"
+<MPClassDivision id="crpg_captain_division_51"
+                   hero="crpg_captain_51"
+                   troop="crpg_captain_51"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1174,9 +1174,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_52"
-                   hero="crpg_character_52"
-                   troop="crpg_character_52"
+<MPClassDivision id="crpg_captain_division_52"
+                   hero="crpg_captain_52"
+                   troop="crpg_captain_52"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1197,9 +1197,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_53"
-                   hero="crpg_character_53"
-                   troop="crpg_character_53"
+<MPClassDivision id="crpg_captain_division_53"
+                   hero="crpg_captain_53"
+                   troop="crpg_captain_53"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1220,9 +1220,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_54"
-                   hero="crpg_character_54"
-                   troop="crpg_character_54"
+<MPClassDivision id="crpg_captain_division_54"
+                   hero="crpg_captain_54"
+                   troop="crpg_captain_54"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1243,9 +1243,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_55"
-                   hero="crpg_character_55"
-                   troop="crpg_character_55"
+<MPClassDivision id="crpg_captain_division_55"
+                   hero="crpg_captain_55"
+                   troop="crpg_captain_55"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1266,9 +1266,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_56"
-                   hero="crpg_character_56"
-                   troop="crpg_character_56"
+<MPClassDivision id="crpg_captain_division_56"
+                   hero="crpg_captain_56"
+                   troop="crpg_captain_56"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1289,9 +1289,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_57"
-                   hero="crpg_character_57"
-                   troop="crpg_character_57"
+<MPClassDivision id="crpg_captain_division_57"
+                   hero="crpg_captain_57"
+                   troop="crpg_captain_57"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1312,9 +1312,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_58"
-                   hero="crpg_character_58"
-                   troop="crpg_character_58"
+<MPClassDivision id="crpg_captain_division_58"
+                   hero="crpg_captain_58"
+                   troop="crpg_captain_58"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1335,9 +1335,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_59"
-                   hero="crpg_character_59"
-                   troop="crpg_character_59"
+<MPClassDivision id="crpg_captain_division_59"
+                   hero="crpg_captain_59"
+                   troop="crpg_captain_59"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1358,9 +1358,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_60"
-                   hero="crpg_character_60"
-                   troop="crpg_character_60"
+<MPClassDivision id="crpg_captain_division_60"
+                   hero="crpg_captain_60"
+                   troop="crpg_captain_60"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1381,9 +1381,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_61"
-                   hero="crpg_character_61"
-                   troop="crpg_character_61"
+<MPClassDivision id="crpg_captain_division_61"
+                   hero="crpg_captain_61"
+                   troop="crpg_captain_61"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1404,9 +1404,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_62"
-                   hero="crpg_character_62"
-                   troop="crpg_character_62"
+<MPClassDivision id="crpg_captain_division_62"
+                   hero="crpg_captain_62"
+                   troop="crpg_captain_62"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1427,9 +1427,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_63"
-                   hero="crpg_character_63"
-                   troop="crpg_character_63"
+<MPClassDivision id="crpg_captain_division_63"
+                   hero="crpg_captain_63"
+                   troop="crpg_captain_63"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1450,9 +1450,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_64"
-                   hero="crpg_character_64"
-                   troop="crpg_character_64"
+<MPClassDivision id="crpg_captain_division_64"
+                   hero="crpg_captain_64"
+                   troop="crpg_captain_64"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1473,9 +1473,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_65"
-                   hero="crpg_character_65"
-                   troop="crpg_character_65"
+<MPClassDivision id="crpg_captain_division_65"
+                   hero="crpg_captain_65"
+                   troop="crpg_captain_65"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1496,9 +1496,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_66"
-                   hero="crpg_character_66"
-                   troop="crpg_character_66"
+<MPClassDivision id="crpg_captain_division_66"
+                   hero="crpg_captain_66"
+                   troop="crpg_captain_66"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1519,9 +1519,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_67"
-                   hero="crpg_character_67"
-                   troop="crpg_character_67"
+<MPClassDivision id="crpg_captain_division_67"
+                   hero="crpg_captain_67"
+                   troop="crpg_captain_67"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1542,9 +1542,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_68"
-                   hero="crpg_character_68"
-                   troop="crpg_character_68"
+<MPClassDivision id="crpg_captain_division_68"
+                   hero="crpg_captain_68"
+                   troop="crpg_captain_68"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1565,9 +1565,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_69"
-                   hero="crpg_character_69"
-                   troop="crpg_character_69"
+<MPClassDivision id="crpg_captain_division_69"
+                   hero="crpg_captain_69"
+                   troop="crpg_captain_69"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1588,9 +1588,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_70"
-                   hero="crpg_character_70"
-                   troop="crpg_character_70"
+<MPClassDivision id="crpg_captain_division_70"
+                   hero="crpg_captain_70"
+                   troop="crpg_captain_70"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1611,9 +1611,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_71"
-                   hero="crpg_character_71"
-                   troop="crpg_character_71"
+<MPClassDivision id="crpg_captain_division_71"
+                   hero="crpg_captain_71"
+                   troop="crpg_captain_71"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1634,9 +1634,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_72"
-                   hero="crpg_character_72"
-                   troop="crpg_character_72"
+<MPClassDivision id="crpg_captain_division_72"
+                   hero="crpg_captain_72"
+                   troop="crpg_captain_72"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1657,9 +1657,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_73"
-                   hero="crpg_character_73"
-                   troop="crpg_character_73"
+<MPClassDivision id="crpg_captain_division_73"
+                   hero="crpg_captain_73"
+                   troop="crpg_captain_73"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1680,9 +1680,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_74"
-                   hero="crpg_character_74"
-                   troop="crpg_character_74"
+<MPClassDivision id="crpg_captain_division_74"
+                   hero="crpg_captain_74"
+                   troop="crpg_captain_74"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1703,9 +1703,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_75"
-                   hero="crpg_character_75"
-                   troop="crpg_character_75"
+<MPClassDivision id="crpg_captain_division_75"
+                   hero="crpg_captain_75"
+                   troop="crpg_captain_75"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1726,9 +1726,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_76"
-                   hero="crpg_character_76"
-                   troop="crpg_character_76"
+<MPClassDivision id="crpg_captain_division_76"
+                   hero="crpg_captain_76"
+                   troop="crpg_captain_76"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1749,9 +1749,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_77"
-                   hero="crpg_character_77"
-                   troop="crpg_character_77"
+<MPClassDivision id="crpg_captain_division_77"
+                   hero="crpg_captain_77"
+                   troop="crpg_captain_77"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1772,9 +1772,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_78"
-                   hero="crpg_character_78"
-                   troop="crpg_character_78"
+<MPClassDivision id="crpg_captain_division_78"
+                   hero="crpg_captain_78"
+                   troop="crpg_captain_78"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1795,9 +1795,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_79"
-                   hero="crpg_character_79"
-                   troop="crpg_character_79"
+<MPClassDivision id="crpg_captain_division_79"
+                   hero="crpg_captain_79"
+                   troop="crpg_captain_79"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1818,9 +1818,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_80"
-                   hero="crpg_character_80"
-                   troop="crpg_character_80"
+<MPClassDivision id="crpg_captain_division_80"
+                   hero="crpg_captain_80"
+                   troop="crpg_captain_80"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1841,9 +1841,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_81"
-                   hero="crpg_character_81"
-                   troop="crpg_character_81"
+<MPClassDivision id="crpg_captain_division_81"
+                   hero="crpg_captain_81"
+                   troop="crpg_captain_81"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1864,9 +1864,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_82"
-                   hero="crpg_character_82"
-                   troop="crpg_character_82"
+<MPClassDivision id="crpg_captain_division_82"
+                   hero="crpg_captain_82"
+                   troop="crpg_captain_82"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1887,9 +1887,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_83"
-                   hero="crpg_character_83"
-                   troop="crpg_character_83"
+<MPClassDivision id="crpg_captain_division_83"
+                   hero="crpg_captain_83"
+                   troop="crpg_captain_83"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1910,9 +1910,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_84"
-                   hero="crpg_character_84"
-                   troop="crpg_character_84"
+<MPClassDivision id="crpg_captain_division_84"
+                   hero="crpg_captain_84"
+                   troop="crpg_captain_84"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1933,9 +1933,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_85"
-                   hero="crpg_character_85"
-                   troop="crpg_character_85"
+<MPClassDivision id="crpg_captain_division_85"
+                   hero="crpg_captain_85"
+                   troop="crpg_captain_85"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1956,9 +1956,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_86"
-                   hero="crpg_character_86"
-                   troop="crpg_character_86"
+<MPClassDivision id="crpg_captain_division_86"
+                   hero="crpg_captain_86"
+                   troop="crpg_captain_86"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -1979,9 +1979,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_87"
-                   hero="crpg_character_87"
-                   troop="crpg_character_87"
+<MPClassDivision id="crpg_captain_division_87"
+                   hero="crpg_captain_87"
+                   troop="crpg_captain_87"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2002,9 +2002,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_88"
-                   hero="crpg_character_88"
-                   troop="crpg_character_88"
+<MPClassDivision id="crpg_captain_division_88"
+                   hero="crpg_captain_88"
+                   troop="crpg_captain_88"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2025,9 +2025,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_89"
-                   hero="crpg_character_89"
-                   troop="crpg_character_89"
+<MPClassDivision id="crpg_captain_division_89"
+                   hero="crpg_captain_89"
+                   troop="crpg_captain_89"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2048,9 +2048,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_90"
-                   hero="crpg_character_90"
-                   troop="crpg_character_90"
+<MPClassDivision id="crpg_captain_division_90"
+                   hero="crpg_captain_90"
+                   troop="crpg_captain_90"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2071,9 +2071,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_91"
-                   hero="crpg_character_91"
-                   troop="crpg_character_91"
+<MPClassDivision id="crpg_captain_division_91"
+                   hero="crpg_captain_91"
+                   troop="crpg_captain_91"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2094,9 +2094,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_92"
-                   hero="crpg_character_92"
-                   troop="crpg_character_92"
+<MPClassDivision id="crpg_captain_division_92"
+                   hero="crpg_captain_92"
+                   troop="crpg_captain_92"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2117,9 +2117,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_93"
-                   hero="crpg_character_93"
-                   troop="crpg_character_93"
+<MPClassDivision id="crpg_captain_division_93"
+                   hero="crpg_captain_93"
+                   troop="crpg_captain_93"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2140,9 +2140,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_94"
-                   hero="crpg_character_94"
-                   troop="crpg_character_94"
+<MPClassDivision id="crpg_captain_division_94"
+                   hero="crpg_captain_94"
+                   troop="crpg_captain_94"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2163,9 +2163,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_95"
-                   hero="crpg_character_95"
-                   troop="crpg_character_95"
+<MPClassDivision id="crpg_captain_division_95"
+                   hero="crpg_captain_95"
+                   troop="crpg_captain_95"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2186,9 +2186,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_96"
-                   hero="crpg_character_96"
-                   troop="crpg_character_96"
+<MPClassDivision id="crpg_captain_division_96"
+                   hero="crpg_captain_96"
+                   troop="crpg_captain_96"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2209,9 +2209,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_97"
-                   hero="crpg_character_97"
-                   troop="crpg_character_97"
+<MPClassDivision id="crpg_captain_division_97"
+                   hero="crpg_captain_97"
+                   troop="crpg_captain_97"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2232,9 +2232,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_98"
-                   hero="crpg_character_98"
-                   troop="crpg_character_98"
+<MPClassDivision id="crpg_captain_division_98"
+                   hero="crpg_captain_98"
+                   troop="crpg_captain_98"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2255,9 +2255,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_99"
-                   hero="crpg_character_99"
-                   troop="crpg_character_99"
+<MPClassDivision id="crpg_captain_division_99"
+                   hero="crpg_captain_99"
+                   troop="crpg_captain_99"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2278,9 +2278,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_100"
-                   hero="crpg_character_100"
-                   troop="crpg_character_100"
+<MPClassDivision id="crpg_captain_division_100"
+                   hero="crpg_captain_100"
+                   troop="crpg_captain_100"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2301,9 +2301,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_101"
-                   hero="crpg_character_101"
-                   troop="crpg_character_101"
+<MPClassDivision id="crpg_captain_division_101"
+                   hero="crpg_captain_101"
+                   troop="crpg_captain_101"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2324,9 +2324,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_102"
-                   hero="crpg_character_102"
-                   troop="crpg_character_102"
+<MPClassDivision id="crpg_captain_division_102"
+                   hero="crpg_captain_102"
+                   troop="crpg_captain_102"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2347,9 +2347,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_103"
-                   hero="crpg_character_103"
-                   troop="crpg_character_103"
+<MPClassDivision id="crpg_captain_division_103"
+                   hero="crpg_captain_103"
+                   troop="crpg_captain_103"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2370,9 +2370,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_104"
-                   hero="crpg_character_104"
-                   troop="crpg_character_104"
+<MPClassDivision id="crpg_captain_division_104"
+                   hero="crpg_captain_104"
+                   troop="crpg_captain_104"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2393,9 +2393,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_105"
-                   hero="crpg_character_105"
-                   troop="crpg_character_105"
+<MPClassDivision id="crpg_captain_division_105"
+                   hero="crpg_captain_105"
+                   troop="crpg_captain_105"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2416,9 +2416,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_106"
-                   hero="crpg_character_106"
-                   troop="crpg_character_106"
+<MPClassDivision id="crpg_captain_division_106"
+                   hero="crpg_captain_106"
+                   troop="crpg_captain_106"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2439,9 +2439,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_107"
-                   hero="crpg_character_107"
-                   troop="crpg_character_107"
+<MPClassDivision id="crpg_captain_division_107"
+                   hero="crpg_captain_107"
+                   troop="crpg_captain_107"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2462,9 +2462,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_108"
-                   hero="crpg_character_108"
-                   troop="crpg_character_108"
+<MPClassDivision id="crpg_captain_division_108"
+                   hero="crpg_captain_108"
+                   troop="crpg_captain_108"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2485,9 +2485,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_109"
-                   hero="crpg_character_109"
-                   troop="crpg_character_109"
+<MPClassDivision id="crpg_captain_division_109"
+                   hero="crpg_captain_109"
+                   troop="crpg_captain_109"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2508,9 +2508,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_110"
-                   hero="crpg_character_110"
-                   troop="crpg_character_110"
+<MPClassDivision id="crpg_captain_division_110"
+                   hero="crpg_captain_110"
+                   troop="crpg_captain_110"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2531,9 +2531,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_111"
-                   hero="crpg_character_111"
-                   troop="crpg_character_111"
+<MPClassDivision id="crpg_captain_division_111"
+                   hero="crpg_captain_111"
+                   troop="crpg_captain_111"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2554,9 +2554,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_112"
-                   hero="crpg_character_112"
-                   troop="crpg_character_112"
+<MPClassDivision id="crpg_captain_division_112"
+                   hero="crpg_captain_112"
+                   troop="crpg_captain_112"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2577,9 +2577,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_113"
-                   hero="crpg_character_113"
-                   troop="crpg_character_113"
+<MPClassDivision id="crpg_captain_division_113"
+                   hero="crpg_captain_113"
+                   troop="crpg_captain_113"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2600,9 +2600,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_114"
-                   hero="crpg_character_114"
-                   troop="crpg_character_114"
+<MPClassDivision id="crpg_captain_division_114"
+                   hero="crpg_captain_114"
+                   troop="crpg_captain_114"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2623,9 +2623,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_115"
-                   hero="crpg_character_115"
-                   troop="crpg_character_115"
+<MPClassDivision id="crpg_captain_division_115"
+                   hero="crpg_captain_115"
+                   troop="crpg_captain_115"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2646,9 +2646,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_116"
-                   hero="crpg_character_116"
-                   troop="crpg_character_116"
+<MPClassDivision id="crpg_captain_division_116"
+                   hero="crpg_captain_116"
+                   troop="crpg_captain_116"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2669,9 +2669,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_117"
-                   hero="crpg_character_117"
-                   troop="crpg_character_117"
+<MPClassDivision id="crpg_captain_division_117"
+                   hero="crpg_captain_117"
+                   troop="crpg_captain_117"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2692,9 +2692,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_118"
-                   hero="crpg_character_118"
-                   troop="crpg_character_118"
+<MPClassDivision id="crpg_captain_division_118"
+                   hero="crpg_captain_118"
+                   troop="crpg_captain_118"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2715,9 +2715,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_119"
-                   hero="crpg_character_119"
-                   troop="crpg_character_119"
+<MPClassDivision id="crpg_captain_division_119"
+                   hero="crpg_captain_119"
+                   troop="crpg_captain_119"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2738,9 +2738,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_120"
-                   hero="crpg_character_120"
-                   troop="crpg_character_120"
+<MPClassDivision id="crpg_captain_division_120"
+                   hero="crpg_captain_120"
+                   troop="crpg_captain_120"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2761,9 +2761,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_121"
-                   hero="crpg_character_121"
-                   troop="crpg_character_121"
+<MPClassDivision id="crpg_captain_division_121"
+                   hero="crpg_captain_121"
+                   troop="crpg_captain_121"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2784,9 +2784,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_122"
-                   hero="crpg_character_122"
-                   troop="crpg_character_122"
+<MPClassDivision id="crpg_captain_division_122"
+                   hero="crpg_captain_122"
+                   troop="crpg_captain_122"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2807,9 +2807,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_123"
-                   hero="crpg_character_123"
-                   troop="crpg_character_123"
+<MPClassDivision id="crpg_captain_division_123"
+                   hero="crpg_captain_123"
+                   troop="crpg_captain_123"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2830,9 +2830,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_124"
-                   hero="crpg_character_124"
-                   troop="crpg_character_124"
+<MPClassDivision id="crpg_captain_division_124"
+                   hero="crpg_captain_124"
+                   troop="crpg_captain_124"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2853,9 +2853,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_125"
-                   hero="crpg_character_125"
-                   troop="crpg_character_125"
+<MPClassDivision id="crpg_captain_division_125"
+                   hero="crpg_captain_125"
+                   troop="crpg_captain_125"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2876,9 +2876,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_126"
-                   hero="crpg_character_126"
-                   troop="crpg_character_126"
+<MPClassDivision id="crpg_captain_division_126"
+                   hero="crpg_captain_126"
+                   troop="crpg_captain_126"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2899,9 +2899,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_127"
-                   hero="crpg_character_127"
-                   troop="crpg_character_127"
+<MPClassDivision id="crpg_captain_division_127"
+                   hero="crpg_captain_127"
+                   troop="crpg_captain_127"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2922,9 +2922,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_128"
-                   hero="crpg_character_128"
-                   troop="crpg_character_128"
+<MPClassDivision id="crpg_captain_division_128"
+                   hero="crpg_captain_128"
+                   troop="crpg_captain_128"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2945,9 +2945,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_129"
-                   hero="crpg_character_129"
-                   troop="crpg_character_129"
+<MPClassDivision id="crpg_captain_division_129"
+                   hero="crpg_captain_129"
+                   troop="crpg_captain_129"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2968,9 +2968,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_130"
-                   hero="crpg_character_130"
-                   troop="crpg_character_130"
+<MPClassDivision id="crpg_captain_division_130"
+                   hero="crpg_captain_130"
+                   troop="crpg_captain_130"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -2991,9 +2991,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_131"
-                   hero="crpg_character_131"
-                   troop="crpg_character_131"
+<MPClassDivision id="crpg_captain_division_131"
+                   hero="crpg_captain_131"
+                   troop="crpg_captain_131"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3014,9 +3014,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_132"
-                   hero="crpg_character_132"
-                   troop="crpg_character_132"
+<MPClassDivision id="crpg_captain_division_132"
+                   hero="crpg_captain_132"
+                   troop="crpg_captain_132"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3037,9 +3037,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_133"
-                   hero="crpg_character_133"
-                   troop="crpg_character_133"
+<MPClassDivision id="crpg_captain_division_133"
+                   hero="crpg_captain_133"
+                   troop="crpg_captain_133"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3060,9 +3060,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_134"
-                   hero="crpg_character_134"
-                   troop="crpg_character_134"
+<MPClassDivision id="crpg_captain_division_134"
+                   hero="crpg_captain_134"
+                   troop="crpg_captain_134"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3083,9 +3083,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_135"
-                   hero="crpg_character_135"
-                   troop="crpg_character_135"
+<MPClassDivision id="crpg_captain_division_135"
+                   hero="crpg_captain_135"
+                   troop="crpg_captain_135"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3106,9 +3106,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_136"
-                   hero="crpg_character_136"
-                   troop="crpg_character_136"
+<MPClassDivision id="crpg_captain_division_136"
+                   hero="crpg_captain_136"
+                   troop="crpg_captain_136"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3129,9 +3129,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_137"
-                   hero="crpg_character_137"
-                   troop="crpg_character_137"
+<MPClassDivision id="crpg_captain_division_137"
+                   hero="crpg_captain_137"
+                   troop="crpg_captain_137"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3152,9 +3152,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_138"
-                   hero="crpg_character_138"
-                   troop="crpg_character_138"
+<MPClassDivision id="crpg_captain_division_138"
+                   hero="crpg_captain_138"
+                   troop="crpg_captain_138"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3175,9 +3175,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_139"
-                   hero="crpg_character_139"
-                   troop="crpg_character_139"
+<MPClassDivision id="crpg_captain_division_139"
+                   hero="crpg_captain_139"
+                   troop="crpg_captain_139"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3198,9 +3198,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_140"
-                   hero="crpg_character_140"
-                   troop="crpg_character_140"
+<MPClassDivision id="crpg_captain_division_140"
+                   hero="crpg_captain_140"
+                   troop="crpg_captain_140"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3221,9 +3221,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_141"
-                   hero="crpg_character_141"
-                   troop="crpg_character_141"
+<MPClassDivision id="crpg_captain_division_141"
+                   hero="crpg_captain_141"
+                   troop="crpg_captain_141"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3244,9 +3244,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_142"
-                   hero="crpg_character_142"
-                   troop="crpg_character_142"
+<MPClassDivision id="crpg_captain_division_142"
+                   hero="crpg_captain_142"
+                   troop="crpg_captain_142"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3267,9 +3267,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_143"
-                   hero="crpg_character_143"
-                   troop="crpg_character_143"
+<MPClassDivision id="crpg_captain_division_143"
+                   hero="crpg_captain_143"
+                   troop="crpg_captain_143"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3290,9 +3290,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_144"
-                   hero="crpg_character_144"
-                   troop="crpg_character_144"
+<MPClassDivision id="crpg_captain_division_144"
+                   hero="crpg_captain_144"
+                   troop="crpg_captain_144"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3313,9 +3313,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_145"
-                   hero="crpg_character_145"
-                   troop="crpg_character_145"
+<MPClassDivision id="crpg_captain_division_145"
+                   hero="crpg_captain_145"
+                   troop="crpg_captain_145"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3336,9 +3336,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_146"
-                   hero="crpg_character_146"
-                   troop="crpg_character_146"
+<MPClassDivision id="crpg_captain_division_146"
+                   hero="crpg_captain_146"
+                   troop="crpg_captain_146"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3359,9 +3359,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_147"
-                   hero="crpg_character_147"
-                   troop="crpg_character_147"
+<MPClassDivision id="crpg_captain_division_147"
+                   hero="crpg_captain_147"
+                   troop="crpg_captain_147"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3382,9 +3382,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_148"
-                   hero="crpg_character_148"
-                   troop="crpg_character_148"
+<MPClassDivision id="crpg_captain_division_148"
+                   hero="crpg_captain_148"
+                   troop="crpg_captain_148"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3405,9 +3405,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_149"
-                   hero="crpg_character_149"
-                   troop="crpg_character_149"
+<MPClassDivision id="crpg_captain_division_149"
+                   hero="crpg_captain_149"
+                   troop="crpg_captain_149"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3428,9 +3428,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_150"
-                   hero="crpg_character_150"
-                   troop="crpg_character_150"
+<MPClassDivision id="crpg_captain_division_150"
+                   hero="crpg_captain_150"
+                   troop="crpg_captain_150"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3451,9 +3451,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_151"
-                   hero="crpg_character_151"
-                   troop="crpg_character_151"
+<MPClassDivision id="crpg_captain_division_151"
+                   hero="crpg_captain_151"
+                   troop="crpg_captain_151"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3474,9 +3474,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_152"
-                   hero="crpg_character_152"
-                   troop="crpg_character_152"
+<MPClassDivision id="crpg_captain_division_152"
+                   hero="crpg_captain_152"
+                   troop="crpg_captain_152"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3497,9 +3497,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_153"
-                   hero="crpg_character_153"
-                   troop="crpg_character_153"
+<MPClassDivision id="crpg_captain_division_153"
+                   hero="crpg_captain_153"
+                   troop="crpg_captain_153"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3520,9 +3520,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_154"
-                   hero="crpg_character_154"
-                   troop="crpg_character_154"
+<MPClassDivision id="crpg_captain_division_154"
+                   hero="crpg_captain_154"
+                   troop="crpg_captain_154"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3543,9 +3543,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_155"
-                   hero="crpg_character_155"
-                   troop="crpg_character_155"
+<MPClassDivision id="crpg_captain_division_155"
+                   hero="crpg_captain_155"
+                   troop="crpg_captain_155"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3566,9 +3566,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_156"
-                   hero="crpg_character_156"
-                   troop="crpg_character_156"
+<MPClassDivision id="crpg_captain_division_156"
+                   hero="crpg_captain_156"
+                   troop="crpg_captain_156"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3589,9 +3589,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_157"
-                   hero="crpg_character_157"
-                   troop="crpg_character_157"
+<MPClassDivision id="crpg_captain_division_157"
+                   hero="crpg_captain_157"
+                   troop="crpg_captain_157"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3612,9 +3612,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_158"
-                   hero="crpg_character_158"
-                   troop="crpg_character_158"
+<MPClassDivision id="crpg_captain_division_158"
+                   hero="crpg_captain_158"
+                   troop="crpg_captain_158"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3635,9 +3635,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_159"
-                   hero="crpg_character_159"
-                   troop="crpg_character_159"
+<MPClassDivision id="crpg_captain_division_159"
+                   hero="crpg_captain_159"
+                   troop="crpg_captain_159"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3658,9 +3658,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_160"
-                   hero="crpg_character_160"
-                   troop="crpg_character_160"
+<MPClassDivision id="crpg_captain_division_160"
+                   hero="crpg_captain_160"
+                   troop="crpg_captain_160"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3681,9 +3681,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_161"
-                   hero="crpg_character_161"
-                   troop="crpg_character_161"
+<MPClassDivision id="crpg_captain_division_161"
+                   hero="crpg_captain_161"
+                   troop="crpg_captain_161"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3704,9 +3704,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_162"
-                   hero="crpg_character_162"
-                   troop="crpg_character_162"
+<MPClassDivision id="crpg_captain_division_162"
+                   hero="crpg_captain_162"
+                   troop="crpg_captain_162"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3727,9 +3727,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_163"
-                   hero="crpg_character_163"
-                   troop="crpg_character_163"
+<MPClassDivision id="crpg_captain_division_163"
+                   hero="crpg_captain_163"
+                   troop="crpg_captain_163"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3750,9 +3750,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_164"
-                   hero="crpg_character_164"
-                   troop="crpg_character_164"
+<MPClassDivision id="crpg_captain_division_164"
+                   hero="crpg_captain_164"
+                   troop="crpg_captain_164"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3773,9 +3773,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_165"
-                   hero="crpg_character_165"
-                   troop="crpg_character_165"
+<MPClassDivision id="crpg_captain_division_165"
+                   hero="crpg_captain_165"
+                   troop="crpg_captain_165"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3796,9 +3796,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_166"
-                   hero="crpg_character_166"
-                   troop="crpg_character_166"
+<MPClassDivision id="crpg_captain_division_166"
+                   hero="crpg_captain_166"
+                   troop="crpg_captain_166"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3819,9 +3819,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_167"
-                   hero="crpg_character_167"
-                   troop="crpg_character_167"
+<MPClassDivision id="crpg_captain_division_167"
+                   hero="crpg_captain_167"
+                   troop="crpg_captain_167"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3842,9 +3842,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_168"
-                   hero="crpg_character_168"
-                   troop="crpg_character_168"
+<MPClassDivision id="crpg_captain_division_168"
+                   hero="crpg_captain_168"
+                   troop="crpg_captain_168"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3865,9 +3865,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_169"
-                   hero="crpg_character_169"
-                   troop="crpg_character_169"
+<MPClassDivision id="crpg_captain_division_169"
+                   hero="crpg_captain_169"
+                   troop="crpg_captain_169"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3888,9 +3888,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_170"
-                   hero="crpg_character_170"
-                   troop="crpg_character_170"
+<MPClassDivision id="crpg_captain_division_170"
+                   hero="crpg_captain_170"
+                   troop="crpg_captain_170"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3911,9 +3911,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_171"
-                   hero="crpg_character_171"
-                   troop="crpg_character_171"
+<MPClassDivision id="crpg_captain_division_171"
+                   hero="crpg_captain_171"
+                   troop="crpg_captain_171"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3934,9 +3934,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_172"
-                   hero="crpg_character_172"
-                   troop="crpg_character_172"
+<MPClassDivision id="crpg_captain_division_172"
+                   hero="crpg_captain_172"
+                   troop="crpg_captain_172"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3957,9 +3957,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_173"
-                   hero="crpg_character_173"
-                   troop="crpg_character_173"
+<MPClassDivision id="crpg_captain_division_173"
+                   hero="crpg_captain_173"
+                   troop="crpg_captain_173"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -3980,9 +3980,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_174"
-                   hero="crpg_character_174"
-                   troop="crpg_character_174"
+<MPClassDivision id="crpg_captain_division_174"
+                   hero="crpg_captain_174"
+                   troop="crpg_captain_174"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4003,9 +4003,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_175"
-                   hero="crpg_character_175"
-                   troop="crpg_character_175"
+<MPClassDivision id="crpg_captain_division_175"
+                   hero="crpg_captain_175"
+                   troop="crpg_captain_175"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4026,9 +4026,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_176"
-                   hero="crpg_character_176"
-                   troop="crpg_character_176"
+<MPClassDivision id="crpg_captain_division_176"
+                   hero="crpg_captain_176"
+                   troop="crpg_captain_176"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4049,9 +4049,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_177"
-                   hero="crpg_character_177"
-                   troop="crpg_character_177"
+<MPClassDivision id="crpg_captain_division_177"
+                   hero="crpg_captain_177"
+                   troop="crpg_captain_177"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4072,9 +4072,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_178"
-                   hero="crpg_character_178"
-                   troop="crpg_character_178"
+<MPClassDivision id="crpg_captain_division_178"
+                   hero="crpg_captain_178"
+                   troop="crpg_captain_178"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4095,9 +4095,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_179"
-                   hero="crpg_character_179"
-                   troop="crpg_character_179"
+<MPClassDivision id="crpg_captain_division_179"
+                   hero="crpg_captain_179"
+                   troop="crpg_captain_179"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4118,9 +4118,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_180"
-                   hero="crpg_character_180"
-                   troop="crpg_character_180"
+<MPClassDivision id="crpg_captain_division_180"
+                   hero="crpg_captain_180"
+                   troop="crpg_captain_180"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4141,9 +4141,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_181"
-                   hero="crpg_character_181"
-                   troop="crpg_character_181"
+<MPClassDivision id="crpg_captain_division_181"
+                   hero="crpg_captain_181"
+                   troop="crpg_captain_181"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4164,9 +4164,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_182"
-                   hero="crpg_character_182"
-                   troop="crpg_character_182"
+<MPClassDivision id="crpg_captain_division_182"
+                   hero="crpg_captain_182"
+                   troop="crpg_captain_182"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4187,9 +4187,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_183"
-                   hero="crpg_character_183"
-                   troop="crpg_character_183"
+<MPClassDivision id="crpg_captain_division_183"
+                   hero="crpg_captain_183"
+                   troop="crpg_captain_183"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4210,9 +4210,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_184"
-                   hero="crpg_character_184"
-                   troop="crpg_character_184"
+<MPClassDivision id="crpg_captain_division_184"
+                   hero="crpg_captain_184"
+                   troop="crpg_captain_184"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4233,9 +4233,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_185"
-                   hero="crpg_character_185"
-                   troop="crpg_character_185"
+<MPClassDivision id="crpg_captain_division_185"
+                   hero="crpg_captain_185"
+                   troop="crpg_captain_185"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4256,9 +4256,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_186"
-                   hero="crpg_character_186"
-                   troop="crpg_character_186"
+<MPClassDivision id="crpg_captain_division_186"
+                   hero="crpg_captain_186"
+                   troop="crpg_captain_186"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4279,9 +4279,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_187"
-                   hero="crpg_character_187"
-                   troop="crpg_character_187"
+<MPClassDivision id="crpg_captain_division_187"
+                   hero="crpg_captain_187"
+                   troop="crpg_captain_187"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4302,9 +4302,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_188"
-                   hero="crpg_character_188"
-                   troop="crpg_character_188"
+<MPClassDivision id="crpg_captain_division_188"
+                   hero="crpg_captain_188"
+                   troop="crpg_captain_188"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4325,9 +4325,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_189"
-                   hero="crpg_character_189"
-                   troop="crpg_character_189"
+<MPClassDivision id="crpg_captain_division_189"
+                   hero="crpg_captain_189"
+                   troop="crpg_captain_189"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4348,9 +4348,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_190"
-                   hero="crpg_character_190"
-                   troop="crpg_character_190"
+<MPClassDivision id="crpg_captain_division_190"
+                   hero="crpg_captain_190"
+                   troop="crpg_captain_190"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4371,9 +4371,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_191"
-                   hero="crpg_character_191"
-                   troop="crpg_character_191"
+<MPClassDivision id="crpg_captain_division_191"
+                   hero="crpg_captain_191"
+                   troop="crpg_captain_191"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4394,9 +4394,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_192"
-                   hero="crpg_character_192"
-                   troop="crpg_character_192"
+<MPClassDivision id="crpg_captain_division_192"
+                   hero="crpg_captain_192"
+                   troop="crpg_captain_192"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4417,9 +4417,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_193"
-                   hero="crpg_character_193"
-                   troop="crpg_character_193"
+<MPClassDivision id="crpg_captain_division_193"
+                   hero="crpg_captain_193"
+                   troop="crpg_captain_193"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4440,9 +4440,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_194"
-                   hero="crpg_character_194"
-                   troop="crpg_character_194"
+<MPClassDivision id="crpg_captain_division_194"
+                   hero="crpg_captain_194"
+                   troop="crpg_captain_194"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4463,9 +4463,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_195"
-                   hero="crpg_character_195"
-                   troop="crpg_character_195"
+<MPClassDivision id="crpg_captain_division_195"
+                   hero="crpg_captain_195"
+                   troop="crpg_captain_195"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4486,9 +4486,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_196"
-                   hero="crpg_character_196"
-                   troop="crpg_character_196"
+<MPClassDivision id="crpg_captain_division_196"
+                   hero="crpg_captain_196"
+                   troop="crpg_captain_196"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4509,9 +4509,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_197"
-                   hero="crpg_character_197"
-                   troop="crpg_character_197"
+<MPClassDivision id="crpg_captain_division_197"
+                   hero="crpg_captain_197"
+                   troop="crpg_captain_197"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4532,9 +4532,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_198"
-                   hero="crpg_character_198"
-                   troop="crpg_character_198"
+<MPClassDivision id="crpg_captain_division_198"
+                   hero="crpg_captain_198"
+                   troop="crpg_captain_198"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4555,9 +4555,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_199"
-                   hero="crpg_character_199"
-                   troop="crpg_character_199"
+<MPClassDivision id="crpg_captain_division_199"
+                   hero="crpg_captain_199"
+                   troop="crpg_captain_199"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4578,9 +4578,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_200"
-                   hero="crpg_character_200"
-                   troop="crpg_character_200"
+<MPClassDivision id="crpg_captain_division_200"
+                   hero="crpg_captain_200"
+                   troop="crpg_captain_200"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4601,9 +4601,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_201"
-                   hero="crpg_character_201"
-                   troop="crpg_character_201"
+<MPClassDivision id="crpg_captain_division_201"
+                   hero="crpg_captain_201"
+                   troop="crpg_captain_201"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4624,9 +4624,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_202"
-                   hero="crpg_character_202"
-                   troop="crpg_character_202"
+<MPClassDivision id="crpg_captain_division_202"
+                   hero="crpg_captain_202"
+                   troop="crpg_captain_202"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4647,9 +4647,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_203"
-                   hero="crpg_character_203"
-                   troop="crpg_character_203"
+<MPClassDivision id="crpg_captain_division_203"
+                   hero="crpg_captain_203"
+                   troop="crpg_captain_203"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4670,9 +4670,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_204"
-                   hero="crpg_character_204"
-                   troop="crpg_character_204"
+<MPClassDivision id="crpg_captain_division_204"
+                   hero="crpg_captain_204"
+                   troop="crpg_captain_204"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4693,9 +4693,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_205"
-                   hero="crpg_character_205"
-                   troop="crpg_character_205"
+<MPClassDivision id="crpg_captain_division_205"
+                   hero="crpg_captain_205"
+                   troop="crpg_captain_205"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4716,9 +4716,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_206"
-                   hero="crpg_character_206"
-                   troop="crpg_character_206"
+<MPClassDivision id="crpg_captain_division_206"
+                   hero="crpg_captain_206"
+                   troop="crpg_captain_206"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4739,9 +4739,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_207"
-                   hero="crpg_character_207"
-                   troop="crpg_character_207"
+<MPClassDivision id="crpg_captain_division_207"
+                   hero="crpg_captain_207"
+                   troop="crpg_captain_207"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4762,9 +4762,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_208"
-                   hero="crpg_character_208"
-                   troop="crpg_character_208"
+<MPClassDivision id="crpg_captain_division_208"
+                   hero="crpg_captain_208"
+                   troop="crpg_captain_208"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4785,9 +4785,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_209"
-                   hero="crpg_character_209"
-                   troop="crpg_character_209"
+<MPClassDivision id="crpg_captain_division_209"
+                   hero="crpg_captain_209"
+                   troop="crpg_captain_209"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4808,9 +4808,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_210"
-                   hero="crpg_character_210"
-                   troop="crpg_character_210"
+<MPClassDivision id="crpg_captain_division_210"
+                   hero="crpg_captain_210"
+                   troop="crpg_captain_210"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4831,9 +4831,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_211"
-                   hero="crpg_character_211"
-                   troop="crpg_character_211"
+<MPClassDivision id="crpg_captain_division_211"
+                   hero="crpg_captain_211"
+                   troop="crpg_captain_211"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4854,9 +4854,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_212"
-                   hero="crpg_character_212"
-                   troop="crpg_character_212"
+<MPClassDivision id="crpg_captain_division_212"
+                   hero="crpg_captain_212"
+                   troop="crpg_captain_212"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4877,9 +4877,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_213"
-                   hero="crpg_character_213"
-                   troop="crpg_character_213"
+<MPClassDivision id="crpg_captain_division_213"
+                   hero="crpg_captain_213"
+                   troop="crpg_captain_213"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4900,9 +4900,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_214"
-                   hero="crpg_character_214"
-                   troop="crpg_character_214"
+<MPClassDivision id="crpg_captain_division_214"
+                   hero="crpg_captain_214"
+                   troop="crpg_captain_214"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4923,9 +4923,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_215"
-                   hero="crpg_character_215"
-                   troop="crpg_character_215"
+<MPClassDivision id="crpg_captain_division_215"
+                   hero="crpg_captain_215"
+                   troop="crpg_captain_215"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4946,9 +4946,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_216"
-                   hero="crpg_character_216"
-                   troop="crpg_character_216"
+<MPClassDivision id="crpg_captain_division_216"
+                   hero="crpg_captain_216"
+                   troop="crpg_captain_216"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4969,9 +4969,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_217"
-                   hero="crpg_character_217"
-                   troop="crpg_character_217"
+<MPClassDivision id="crpg_captain_division_217"
+                   hero="crpg_captain_217"
+                   troop="crpg_captain_217"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -4992,9 +4992,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_218"
-                   hero="crpg_character_218"
-                   troop="crpg_character_218"
+<MPClassDivision id="crpg_captain_division_218"
+                   hero="crpg_captain_218"
+                   troop="crpg_captain_218"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5015,9 +5015,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_219"
-                   hero="crpg_character_219"
-                   troop="crpg_character_219"
+<MPClassDivision id="crpg_captain_division_219"
+                   hero="crpg_captain_219"
+                   troop="crpg_captain_219"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5038,9 +5038,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_220"
-                   hero="crpg_character_220"
-                   troop="crpg_character_220"
+<MPClassDivision id="crpg_captain_division_220"
+                   hero="crpg_captain_220"
+                   troop="crpg_captain_220"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5061,9 +5061,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_221"
-                   hero="crpg_character_221"
-                   troop="crpg_character_221"
+<MPClassDivision id="crpg_captain_division_221"
+                   hero="crpg_captain_221"
+                   troop="crpg_captain_221"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5084,9 +5084,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_222"
-                   hero="crpg_character_222"
-                   troop="crpg_character_222"
+<MPClassDivision id="crpg_captain_division_222"
+                   hero="crpg_captain_222"
+                   troop="crpg_captain_222"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5107,9 +5107,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_223"
-                   hero="crpg_character_223"
-                   troop="crpg_character_223"
+<MPClassDivision id="crpg_captain_division_223"
+                   hero="crpg_captain_223"
+                   troop="crpg_captain_223"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5130,9 +5130,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_224"
-                   hero="crpg_character_224"
-                   troop="crpg_character_224"
+<MPClassDivision id="crpg_captain_division_224"
+                   hero="crpg_captain_224"
+                   troop="crpg_captain_224"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5153,9 +5153,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_225"
-                   hero="crpg_character_225"
-                   troop="crpg_character_225"
+<MPClassDivision id="crpg_captain_division_225"
+                   hero="crpg_captain_225"
+                   troop="crpg_captain_225"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5176,9 +5176,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_226"
-                   hero="crpg_character_226"
-                   troop="crpg_character_226"
+<MPClassDivision id="crpg_captain_division_226"
+                   hero="crpg_captain_226"
+                   troop="crpg_captain_226"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5199,9 +5199,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_227"
-                   hero="crpg_character_227"
-                   troop="crpg_character_227"
+<MPClassDivision id="crpg_captain_division_227"
+                   hero="crpg_captain_227"
+                   troop="crpg_captain_227"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5222,9 +5222,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_228"
-                   hero="crpg_character_228"
-                   troop="crpg_character_228"
+<MPClassDivision id="crpg_captain_division_228"
+                   hero="crpg_captain_228"
+                   troop="crpg_captain_228"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5245,9 +5245,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_229"
-                   hero="crpg_character_229"
-                   troop="crpg_character_229"
+<MPClassDivision id="crpg_captain_division_229"
+                   hero="crpg_captain_229"
+                   troop="crpg_captain_229"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5268,9 +5268,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_230"
-                   hero="crpg_character_230"
-                   troop="crpg_character_230"
+<MPClassDivision id="crpg_captain_division_230"
+                   hero="crpg_captain_230"
+                   troop="crpg_captain_230"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5291,9 +5291,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_231"
-                   hero="crpg_character_231"
-                   troop="crpg_character_231"
+<MPClassDivision id="crpg_captain_division_231"
+                   hero="crpg_captain_231"
+                   troop="crpg_captain_231"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5314,9 +5314,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_232"
-                   hero="crpg_character_232"
-                   troop="crpg_character_232"
+<MPClassDivision id="crpg_captain_division_232"
+                   hero="crpg_captain_232"
+                   troop="crpg_captain_232"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5337,9 +5337,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_233"
-                   hero="crpg_character_233"
-                   troop="crpg_character_233"
+<MPClassDivision id="crpg_captain_division_233"
+                   hero="crpg_captain_233"
+                   troop="crpg_captain_233"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5360,9 +5360,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_234"
-                   hero="crpg_character_234"
-                   troop="crpg_character_234"
+<MPClassDivision id="crpg_captain_division_234"
+                   hero="crpg_captain_234"
+                   troop="crpg_captain_234"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5383,9 +5383,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_235"
-                   hero="crpg_character_235"
-                   troop="crpg_character_235"
+<MPClassDivision id="crpg_captain_division_235"
+                   hero="crpg_captain_235"
+                   troop="crpg_captain_235"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5406,9 +5406,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_236"
-                   hero="crpg_character_236"
-                   troop="crpg_character_236"
+<MPClassDivision id="crpg_captain_division_236"
+                   hero="crpg_captain_236"
+                   troop="crpg_captain_236"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5429,9 +5429,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_237"
-                   hero="crpg_character_237"
-                   troop="crpg_character_237"
+<MPClassDivision id="crpg_captain_division_237"
+                   hero="crpg_captain_237"
+                   troop="crpg_captain_237"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5452,9 +5452,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_238"
-                   hero="crpg_character_238"
-                   troop="crpg_character_238"
+<MPClassDivision id="crpg_captain_division_238"
+                   hero="crpg_captain_238"
+                   troop="crpg_captain_238"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5475,9 +5475,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_239"
-                   hero="crpg_character_239"
-                   troop="crpg_character_239"
+<MPClassDivision id="crpg_captain_division_239"
+                   hero="crpg_captain_239"
+                   troop="crpg_captain_239"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5498,9 +5498,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_240"
-                   hero="crpg_character_240"
-                   troop="crpg_character_240"
+<MPClassDivision id="crpg_captain_division_240"
+                   hero="crpg_captain_240"
+                   troop="crpg_captain_240"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5521,9 +5521,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_241"
-                   hero="crpg_character_241"
-                   troop="crpg_character_241"
+<MPClassDivision id="crpg_captain_division_241"
+                   hero="crpg_captain_241"
+                   troop="crpg_captain_241"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5544,9 +5544,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_242"
-                   hero="crpg_character_242"
-                   troop="crpg_character_242"
+<MPClassDivision id="crpg_captain_division_242"
+                   hero="crpg_captain_242"
+                   troop="crpg_captain_242"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5567,9 +5567,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_243"
-                   hero="crpg_character_243"
-                   troop="crpg_character_243"
+<MPClassDivision id="crpg_captain_division_243"
+                   hero="crpg_captain_243"
+                   troop="crpg_captain_243"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5590,9 +5590,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_244"
-                   hero="crpg_character_244"
-                   troop="crpg_character_244"
+<MPClassDivision id="crpg_captain_division_244"
+                   hero="crpg_captain_244"
+                   troop="crpg_captain_244"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5613,9 +5613,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_245"
-                   hero="crpg_character_245"
-                   troop="crpg_character_245"
+<MPClassDivision id="crpg_captain_division_245"
+                   hero="crpg_captain_245"
+                   troop="crpg_captain_245"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5636,9 +5636,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_246"
-                   hero="crpg_character_246"
-                   troop="crpg_character_246"
+<MPClassDivision id="crpg_captain_division_246"
+                   hero="crpg_captain_246"
+                   troop="crpg_captain_246"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5659,9 +5659,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_247"
-                   hero="crpg_character_247"
-                   troop="crpg_character_247"
+<MPClassDivision id="crpg_captain_division_247"
+                   hero="crpg_captain_247"
+                   troop="crpg_captain_247"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5682,9 +5682,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_248"
-                   hero="crpg_character_248"
-                   troop="crpg_character_248"
+<MPClassDivision id="crpg_captain_division_248"
+                   hero="crpg_captain_248"
+                   troop="crpg_captain_248"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5705,9 +5705,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_249"
-                   hero="crpg_character_249"
-                   troop="crpg_character_249"
+<MPClassDivision id="crpg_captain_division_249"
+                   hero="crpg_captain_249"
+                   troop="crpg_captain_249"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5728,9 +5728,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_250"
-                   hero="crpg_character_250"
-                   troop="crpg_character_250"
+<MPClassDivision id="crpg_captain_division_250"
+                   hero="crpg_captain_250"
+                   troop="crpg_captain_250"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5751,9 +5751,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_251"
-                   hero="crpg_character_251"
-                   troop="crpg_character_251"
+<MPClassDivision id="crpg_captain_division_251"
+                   hero="crpg_captain_251"
+                   troop="crpg_captain_251"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5774,9 +5774,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_252"
-                   hero="crpg_character_252"
-                   troop="crpg_character_252"
+<MPClassDivision id="crpg_captain_division_252"
+                   hero="crpg_captain_252"
+                   troop="crpg_captain_252"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5797,9 +5797,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_253"
-                   hero="crpg_character_253"
-                   troop="crpg_character_253"
+<MPClassDivision id="crpg_captain_division_253"
+                   hero="crpg_captain_253"
+                   troop="crpg_captain_253"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5820,9 +5820,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_254"
-                   hero="crpg_character_254"
-                   troop="crpg_character_254"
+<MPClassDivision id="crpg_captain_division_254"
+                   hero="crpg_captain_254"
+                   troop="crpg_captain_254"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5843,9 +5843,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_255"
-                   hero="crpg_character_255"
-                   troop="crpg_character_255"
+<MPClassDivision id="crpg_captain_division_255"
+                   hero="crpg_captain_255"
+                   troop="crpg_captain_255"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5866,9 +5866,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_256"
-                   hero="crpg_character_256"
-                   troop="crpg_character_256"
+<MPClassDivision id="crpg_captain_division_256"
+                   hero="crpg_captain_256"
+                   troop="crpg_captain_256"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5889,9 +5889,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_257"
-                   hero="crpg_character_257"
-                   troop="crpg_character_257"
+<MPClassDivision id="crpg_captain_division_257"
+                   hero="crpg_captain_257"
+                   troop="crpg_captain_257"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5912,9 +5912,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_258"
-                   hero="crpg_character_258"
-                   troop="crpg_character_258"
+<MPClassDivision id="crpg_captain_division_258"
+                   hero="crpg_captain_258"
+                   troop="crpg_captain_258"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5935,9 +5935,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_259"
-                   hero="crpg_character_259"
-                   troop="crpg_character_259"
+<MPClassDivision id="crpg_captain_division_259"
+                   hero="crpg_captain_259"
+                   troop="crpg_captain_259"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5958,9 +5958,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_260"
-                   hero="crpg_character_260"
-                   troop="crpg_character_260"
+<MPClassDivision id="crpg_captain_division_260"
+                   hero="crpg_captain_260"
+                   troop="crpg_captain_260"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -5981,9 +5981,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_261"
-                   hero="crpg_character_261"
-                   troop="crpg_character_261"
+<MPClassDivision id="crpg_captain_division_261"
+                   hero="crpg_captain_261"
+                   troop="crpg_captain_261"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6004,9 +6004,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_262"
-                   hero="crpg_character_262"
-                   troop="crpg_character_262"
+<MPClassDivision id="crpg_captain_division_262"
+                   hero="crpg_captain_262"
+                   troop="crpg_captain_262"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6027,9 +6027,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_263"
-                   hero="crpg_character_263"
-                   troop="crpg_character_263"
+<MPClassDivision id="crpg_captain_division_263"
+                   hero="crpg_captain_263"
+                   troop="crpg_captain_263"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6050,9 +6050,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_264"
-                   hero="crpg_character_264"
-                   troop="crpg_character_264"
+<MPClassDivision id="crpg_captain_division_264"
+                   hero="crpg_captain_264"
+                   troop="crpg_captain_264"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6073,9 +6073,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_265"
-                   hero="crpg_character_265"
-                   troop="crpg_character_265"
+<MPClassDivision id="crpg_captain_division_265"
+                   hero="crpg_captain_265"
+                   troop="crpg_captain_265"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6096,9 +6096,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_266"
-                   hero="crpg_character_266"
-                   troop="crpg_character_266"
+<MPClassDivision id="crpg_captain_division_266"
+                   hero="crpg_captain_266"
+                   troop="crpg_captain_266"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6119,9 +6119,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_267"
-                   hero="crpg_character_267"
-                   troop="crpg_character_267"
+<MPClassDivision id="crpg_captain_division_267"
+                   hero="crpg_captain_267"
+                   troop="crpg_captain_267"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6142,9 +6142,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_268"
-                   hero="crpg_character_268"
-                   troop="crpg_character_268"
+<MPClassDivision id="crpg_captain_division_268"
+                   hero="crpg_captain_268"
+                   troop="crpg_captain_268"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6165,9 +6165,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_269"
-                   hero="crpg_character_269"
-                   troop="crpg_character_269"
+<MPClassDivision id="crpg_captain_division_269"
+                   hero="crpg_captain_269"
+                   troop="crpg_captain_269"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6188,9 +6188,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_270"
-                   hero="crpg_character_270"
-                   troop="crpg_character_270"
+<MPClassDivision id="crpg_captain_division_270"
+                   hero="crpg_captain_270"
+                   troop="crpg_captain_270"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6211,9 +6211,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_271"
-                   hero="crpg_character_271"
-                   troop="crpg_character_271"
+<MPClassDivision id="crpg_captain_division_271"
+                   hero="crpg_captain_271"
+                   troop="crpg_captain_271"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6234,9 +6234,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_272"
-                   hero="crpg_character_272"
-                   troop="crpg_character_272"
+<MPClassDivision id="crpg_captain_division_272"
+                   hero="crpg_captain_272"
+                   troop="crpg_captain_272"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6257,9 +6257,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_273"
-                   hero="crpg_character_273"
-                   troop="crpg_character_273"
+<MPClassDivision id="crpg_captain_division_273"
+                   hero="crpg_captain_273"
+                   troop="crpg_captain_273"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6280,9 +6280,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_274"
-                   hero="crpg_character_274"
-                   troop="crpg_character_274"
+<MPClassDivision id="crpg_captain_division_274"
+                   hero="crpg_captain_274"
+                   troop="crpg_captain_274"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6303,9 +6303,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_275"
-                   hero="crpg_character_275"
-                   troop="crpg_character_275"
+<MPClassDivision id="crpg_captain_division_275"
+                   hero="crpg_captain_275"
+                   troop="crpg_captain_275"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6326,9 +6326,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_276"
-                   hero="crpg_character_276"
-                   troop="crpg_character_276"
+<MPClassDivision id="crpg_captain_division_276"
+                   hero="crpg_captain_276"
+                   troop="crpg_captain_276"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6349,9 +6349,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_277"
-                   hero="crpg_character_277"
-                   troop="crpg_character_277"
+<MPClassDivision id="crpg_captain_division_277"
+                   hero="crpg_captain_277"
+                   troop="crpg_captain_277"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6372,9 +6372,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_278"
-                   hero="crpg_character_278"
-                   troop="crpg_character_278"
+<MPClassDivision id="crpg_captain_division_278"
+                   hero="crpg_captain_278"
+                   troop="crpg_captain_278"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6395,9 +6395,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_279"
-                   hero="crpg_character_279"
-                   troop="crpg_character_279"
+<MPClassDivision id="crpg_captain_division_279"
+                   hero="crpg_captain_279"
+                   troop="crpg_captain_279"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6418,9 +6418,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_280"
-                   hero="crpg_character_280"
-                   troop="crpg_character_280"
+<MPClassDivision id="crpg_captain_division_280"
+                   hero="crpg_captain_280"
+                   troop="crpg_captain_280"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6441,9 +6441,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_281"
-                   hero="crpg_character_281"
-                   troop="crpg_character_281"
+<MPClassDivision id="crpg_captain_division_281"
+                   hero="crpg_captain_281"
+                   troop="crpg_captain_281"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6464,9 +6464,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_282"
-                   hero="crpg_character_282"
-                   troop="crpg_character_282"
+<MPClassDivision id="crpg_captain_division_282"
+                   hero="crpg_captain_282"
+                   troop="crpg_captain_282"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6487,9 +6487,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_283"
-                   hero="crpg_character_283"
-                   troop="crpg_character_283"
+<MPClassDivision id="crpg_captain_division_283"
+                   hero="crpg_captain_283"
+                   troop="crpg_captain_283"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6510,9 +6510,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_284"
-                   hero="crpg_character_284"
-                   troop="crpg_character_284"
+<MPClassDivision id="crpg_captain_division_284"
+                   hero="crpg_captain_284"
+                   troop="crpg_captain_284"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6533,9 +6533,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_285"
-                   hero="crpg_character_285"
-                   troop="crpg_character_285"
+<MPClassDivision id="crpg_captain_division_285"
+                   hero="crpg_captain_285"
+                   troop="crpg_captain_285"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6556,9 +6556,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_286"
-                   hero="crpg_character_286"
-                   troop="crpg_character_286"
+<MPClassDivision id="crpg_captain_division_286"
+                   hero="crpg_captain_286"
+                   troop="crpg_captain_286"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6579,9 +6579,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_287"
-                   hero="crpg_character_287"
-                   troop="crpg_character_287"
+<MPClassDivision id="crpg_captain_division_287"
+                   hero="crpg_captain_287"
+                   troop="crpg_captain_287"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6602,9 +6602,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_288"
-                   hero="crpg_character_288"
-                   troop="crpg_character_288"
+<MPClassDivision id="crpg_captain_division_288"
+                   hero="crpg_captain_288"
+                   troop="crpg_captain_288"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6625,9 +6625,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_289"
-                   hero="crpg_character_289"
-                   troop="crpg_character_289"
+<MPClassDivision id="crpg_captain_division_289"
+                   hero="crpg_captain_289"
+                   troop="crpg_captain_289"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6648,9 +6648,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_290"
-                   hero="crpg_character_290"
-                   troop="crpg_character_290"
+<MPClassDivision id="crpg_captain_division_290"
+                   hero="crpg_captain_290"
+                   troop="crpg_captain_290"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6671,9 +6671,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_291"
-                   hero="crpg_character_291"
-                   troop="crpg_character_291"
+<MPClassDivision id="crpg_captain_division_291"
+                   hero="crpg_captain_291"
+                   troop="crpg_captain_291"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6694,9 +6694,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_292"
-                   hero="crpg_character_292"
-                   troop="crpg_character_292"
+<MPClassDivision id="crpg_captain_division_292"
+                   hero="crpg_captain_292"
+                   troop="crpg_captain_292"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6717,9 +6717,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_293"
-                   hero="crpg_character_293"
-                   troop="crpg_character_293"
+<MPClassDivision id="crpg_captain_division_293"
+                   hero="crpg_captain_293"
+                   troop="crpg_captain_293"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6740,9 +6740,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_294"
-                   hero="crpg_character_294"
-                   troop="crpg_character_294"
+<MPClassDivision id="crpg_captain_division_294"
+                   hero="crpg_captain_294"
+                   troop="crpg_captain_294"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6763,9 +6763,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_295"
-                   hero="crpg_character_295"
-                   troop="crpg_character_295"
+<MPClassDivision id="crpg_captain_division_295"
+                   hero="crpg_captain_295"
+                   troop="crpg_captain_295"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6786,9 +6786,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_296"
-                   hero="crpg_character_296"
-                   troop="crpg_character_296"
+<MPClassDivision id="crpg_captain_division_296"
+                   hero="crpg_captain_296"
+                   troop="crpg_captain_296"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6809,9 +6809,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_297"
-                   hero="crpg_character_297"
-                   troop="crpg_character_297"
+<MPClassDivision id="crpg_captain_division_297"
+                   hero="crpg_captain_297"
+                   troop="crpg_captain_297"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6832,9 +6832,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_298"
-                   hero="crpg_character_298"
-                   troop="crpg_character_298"
+<MPClassDivision id="crpg_captain_division_298"
+                   hero="crpg_captain_298"
+                   troop="crpg_captain_298"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6855,9 +6855,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_299"
-                   hero="crpg_character_299"
-                   troop="crpg_character_299"
+<MPClassDivision id="crpg_captain_division_299"
+                   hero="crpg_captain_299"
+                   troop="crpg_captain_299"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6878,9 +6878,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_300"
-                   hero="crpg_character_300"
-                   troop="crpg_character_300"
+<MPClassDivision id="crpg_captain_division_300"
+                   hero="crpg_captain_300"
+                   troop="crpg_captain_300"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6901,9 +6901,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_301"
-                   hero="crpg_character_301"
-                   troop="crpg_character_301"
+<MPClassDivision id="crpg_captain_division_301"
+                   hero="crpg_captain_301"
+                   troop="crpg_captain_301"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6924,9 +6924,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_302"
-                   hero="crpg_character_302"
-                   troop="crpg_character_302"
+<MPClassDivision id="crpg_captain_division_302"
+                   hero="crpg_captain_302"
+                   troop="crpg_captain_302"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6947,9 +6947,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_303"
-                   hero="crpg_character_303"
-                   troop="crpg_character_303"
+<MPClassDivision id="crpg_captain_division_303"
+                   hero="crpg_captain_303"
+                   troop="crpg_captain_303"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6970,9 +6970,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_304"
-                   hero="crpg_character_304"
-                   troop="crpg_character_304"
+<MPClassDivision id="crpg_captain_division_304"
+                   hero="crpg_captain_304"
+                   troop="crpg_captain_304"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -6993,9 +6993,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_305"
-                   hero="crpg_character_305"
-                   troop="crpg_character_305"
+<MPClassDivision id="crpg_captain_division_305"
+                   hero="crpg_captain_305"
+                   troop="crpg_captain_305"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7016,9 +7016,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_306"
-                   hero="crpg_character_306"
-                   troop="crpg_character_306"
+<MPClassDivision id="crpg_captain_division_306"
+                   hero="crpg_captain_306"
+                   troop="crpg_captain_306"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7039,9 +7039,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_307"
-                   hero="crpg_character_307"
-                   troop="crpg_character_307"
+<MPClassDivision id="crpg_captain_division_307"
+                   hero="crpg_captain_307"
+                   troop="crpg_captain_307"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7062,9 +7062,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_308"
-                   hero="crpg_character_308"
-                   troop="crpg_character_308"
+<MPClassDivision id="crpg_captain_division_308"
+                   hero="crpg_captain_308"
+                   troop="crpg_captain_308"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7085,9 +7085,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_309"
-                   hero="crpg_character_309"
-                   troop="crpg_character_309"
+<MPClassDivision id="crpg_captain_division_309"
+                   hero="crpg_captain_309"
+                   troop="crpg_captain_309"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7108,9 +7108,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_310"
-                   hero="crpg_character_310"
-                   troop="crpg_character_310"
+<MPClassDivision id="crpg_captain_division_310"
+                   hero="crpg_captain_310"
+                   troop="crpg_captain_310"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7131,9 +7131,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_311"
-                   hero="crpg_character_311"
-                   troop="crpg_character_311"
+<MPClassDivision id="crpg_captain_division_311"
+                   hero="crpg_captain_311"
+                   troop="crpg_captain_311"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7154,9 +7154,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_312"
-                   hero="crpg_character_312"
-                   troop="crpg_character_312"
+<MPClassDivision id="crpg_captain_division_312"
+                   hero="crpg_captain_312"
+                   troop="crpg_captain_312"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7177,9 +7177,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_313"
-                   hero="crpg_character_313"
-                   troop="crpg_character_313"
+<MPClassDivision id="crpg_captain_division_313"
+                   hero="crpg_captain_313"
+                   troop="crpg_captain_313"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7200,9 +7200,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_314"
-                   hero="crpg_character_314"
-                   troop="crpg_character_314"
+<MPClassDivision id="crpg_captain_division_314"
+                   hero="crpg_captain_314"
+                   troop="crpg_captain_314"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7223,9 +7223,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_315"
-                   hero="crpg_character_315"
-                   troop="crpg_character_315"
+<MPClassDivision id="crpg_captain_division_315"
+                   hero="crpg_captain_315"
+                   troop="crpg_captain_315"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7246,9 +7246,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_316"
-                   hero="crpg_character_316"
-                   troop="crpg_character_316"
+<MPClassDivision id="crpg_captain_division_316"
+                   hero="crpg_captain_316"
+                   troop="crpg_captain_316"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7269,9 +7269,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_317"
-                   hero="crpg_character_317"
-                   troop="crpg_character_317"
+<MPClassDivision id="crpg_captain_division_317"
+                   hero="crpg_captain_317"
+                   troop="crpg_captain_317"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7292,9 +7292,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_318"
-                   hero="crpg_character_318"
-                   troop="crpg_character_318"
+<MPClassDivision id="crpg_captain_division_318"
+                   hero="crpg_captain_318"
+                   troop="crpg_captain_318"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7315,9 +7315,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_319"
-                   hero="crpg_character_319"
-                   troop="crpg_character_319"
+<MPClassDivision id="crpg_captain_division_319"
+                   hero="crpg_captain_319"
+                   troop="crpg_captain_319"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7338,9 +7338,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_320"
-                   hero="crpg_character_320"
-                   troop="crpg_character_320"
+<MPClassDivision id="crpg_captain_division_320"
+                   hero="crpg_captain_320"
+                   troop="crpg_captain_320"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7361,9 +7361,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_321"
-                   hero="crpg_character_321"
-                   troop="crpg_character_321"
+<MPClassDivision id="crpg_captain_division_321"
+                   hero="crpg_captain_321"
+                   troop="crpg_captain_321"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7384,9 +7384,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_322"
-                   hero="crpg_character_322"
-                   troop="crpg_character_322"
+<MPClassDivision id="crpg_captain_division_322"
+                   hero="crpg_captain_322"
+                   troop="crpg_captain_322"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7407,9 +7407,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_323"
-                   hero="crpg_character_323"
-                   troop="crpg_character_323"
+<MPClassDivision id="crpg_captain_division_323"
+                   hero="crpg_captain_323"
+                   troop="crpg_captain_323"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7430,9 +7430,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_324"
-                   hero="crpg_character_324"
-                   troop="crpg_character_324"
+<MPClassDivision id="crpg_captain_division_324"
+                   hero="crpg_captain_324"
+                   troop="crpg_captain_324"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7453,9 +7453,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_325"
-                   hero="crpg_character_325"
-                   troop="crpg_character_325"
+<MPClassDivision id="crpg_captain_division_325"
+                   hero="crpg_captain_325"
+                   troop="crpg_captain_325"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7476,9 +7476,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_326"
-                   hero="crpg_character_326"
-                   troop="crpg_character_326"
+<MPClassDivision id="crpg_captain_division_326"
+                   hero="crpg_captain_326"
+                   troop="crpg_captain_326"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7499,9 +7499,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_327"
-                   hero="crpg_character_327"
-                   troop="crpg_character_327"
+<MPClassDivision id="crpg_captain_division_327"
+                   hero="crpg_captain_327"
+                   troop="crpg_captain_327"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7522,9 +7522,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_328"
-                   hero="crpg_character_328"
-                   troop="crpg_character_328"
+<MPClassDivision id="crpg_captain_division_328"
+                   hero="crpg_captain_328"
+                   troop="crpg_captain_328"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7545,9 +7545,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_329"
-                   hero="crpg_character_329"
-                   troop="crpg_character_329"
+<MPClassDivision id="crpg_captain_division_329"
+                   hero="crpg_captain_329"
+                   troop="crpg_captain_329"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7568,9 +7568,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_330"
-                   hero="crpg_character_330"
-                   troop="crpg_character_330"
+<MPClassDivision id="crpg_captain_division_330"
+                   hero="crpg_captain_330"
+                   troop="crpg_captain_330"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7591,9 +7591,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_331"
-                   hero="crpg_character_331"
-                   troop="crpg_character_331"
+<MPClassDivision id="crpg_captain_division_331"
+                   hero="crpg_captain_331"
+                   troop="crpg_captain_331"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7614,9 +7614,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_332"
-                   hero="crpg_character_332"
-                   troop="crpg_character_332"
+<MPClassDivision id="crpg_captain_division_332"
+                   hero="crpg_captain_332"
+                   troop="crpg_captain_332"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7637,9 +7637,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_333"
-                   hero="crpg_character_333"
-                   troop="crpg_character_333"
+<MPClassDivision id="crpg_captain_division_333"
+                   hero="crpg_captain_333"
+                   troop="crpg_captain_333"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7660,9 +7660,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_334"
-                   hero="crpg_character_334"
-                   troop="crpg_character_334"
+<MPClassDivision id="crpg_captain_division_334"
+                   hero="crpg_captain_334"
+                   troop="crpg_captain_334"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7683,9 +7683,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_335"
-                   hero="crpg_character_335"
-                   troop="crpg_character_335"
+<MPClassDivision id="crpg_captain_division_335"
+                   hero="crpg_captain_335"
+                   troop="crpg_captain_335"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7706,9 +7706,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_336"
-                   hero="crpg_character_336"
-                   troop="crpg_character_336"
+<MPClassDivision id="crpg_captain_division_336"
+                   hero="crpg_captain_336"
+                   troop="crpg_captain_336"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7729,9 +7729,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_337"
-                   hero="crpg_character_337"
-                   troop="crpg_character_337"
+<MPClassDivision id="crpg_captain_division_337"
+                   hero="crpg_captain_337"
+                   troop="crpg_captain_337"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7752,9 +7752,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_338"
-                   hero="crpg_character_338"
-                   troop="crpg_character_338"
+<MPClassDivision id="crpg_captain_division_338"
+                   hero="crpg_captain_338"
+                   troop="crpg_captain_338"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7775,9 +7775,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_339"
-                   hero="crpg_character_339"
-                   troop="crpg_character_339"
+<MPClassDivision id="crpg_captain_division_339"
+                   hero="crpg_captain_339"
+                   troop="crpg_captain_339"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7798,9 +7798,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_340"
-                   hero="crpg_character_340"
-                   troop="crpg_character_340"
+<MPClassDivision id="crpg_captain_division_340"
+                   hero="crpg_captain_340"
+                   troop="crpg_captain_340"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7821,9 +7821,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_341"
-                   hero="crpg_character_341"
-                   troop="crpg_character_341"
+<MPClassDivision id="crpg_captain_division_341"
+                   hero="crpg_captain_341"
+                   troop="crpg_captain_341"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7844,9 +7844,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_342"
-                   hero="crpg_character_342"
-                   troop="crpg_character_342"
+<MPClassDivision id="crpg_captain_division_342"
+                   hero="crpg_captain_342"
+                   troop="crpg_captain_342"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7867,9 +7867,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_343"
-                   hero="crpg_character_343"
-                   troop="crpg_character_343"
+<MPClassDivision id="crpg_captain_division_343"
+                   hero="crpg_captain_343"
+                   troop="crpg_captain_343"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7890,9 +7890,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_344"
-                   hero="crpg_character_344"
-                   troop="crpg_character_344"
+<MPClassDivision id="crpg_captain_division_344"
+                   hero="crpg_captain_344"
+                   troop="crpg_captain_344"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7913,9 +7913,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_345"
-                   hero="crpg_character_345"
-                   troop="crpg_character_345"
+<MPClassDivision id="crpg_captain_division_345"
+                   hero="crpg_captain_345"
+                   troop="crpg_captain_345"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7936,9 +7936,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_346"
-                   hero="crpg_character_346"
-                   troop="crpg_character_346"
+<MPClassDivision id="crpg_captain_division_346"
+                   hero="crpg_captain_346"
+                   troop="crpg_captain_346"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7959,9 +7959,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_347"
-                   hero="crpg_character_347"
-                   troop="crpg_character_347"
+<MPClassDivision id="crpg_captain_division_347"
+                   hero="crpg_captain_347"
+                   troop="crpg_captain_347"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -7982,9 +7982,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_348"
-                   hero="crpg_character_348"
-                   troop="crpg_character_348"
+<MPClassDivision id="crpg_captain_division_348"
+                   hero="crpg_captain_348"
+                   troop="crpg_captain_348"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8005,9 +8005,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_349"
-                   hero="crpg_character_349"
-                   troop="crpg_character_349"
+<MPClassDivision id="crpg_captain_division_349"
+                   hero="crpg_captain_349"
+                   troop="crpg_captain_349"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8028,9 +8028,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_350"
-                   hero="crpg_character_350"
-                   troop="crpg_character_350"
+<MPClassDivision id="crpg_captain_division_350"
+                   hero="crpg_captain_350"
+                   troop="crpg_captain_350"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8051,9 +8051,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_351"
-                   hero="crpg_character_351"
-                   troop="crpg_character_351"
+<MPClassDivision id="crpg_captain_division_351"
+                   hero="crpg_captain_351"
+                   troop="crpg_captain_351"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8074,9 +8074,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_352"
-                   hero="crpg_character_352"
-                   troop="crpg_character_352"
+<MPClassDivision id="crpg_captain_division_352"
+                   hero="crpg_captain_352"
+                   troop="crpg_captain_352"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8097,9 +8097,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_353"
-                   hero="crpg_character_353"
-                   troop="crpg_character_353"
+<MPClassDivision id="crpg_captain_division_353"
+                   hero="crpg_captain_353"
+                   troop="crpg_captain_353"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8120,9 +8120,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_354"
-                   hero="crpg_character_354"
-                   troop="crpg_character_354"
+<MPClassDivision id="crpg_captain_division_354"
+                   hero="crpg_captain_354"
+                   troop="crpg_captain_354"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8143,9 +8143,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_355"
-                   hero="crpg_character_355"
-                   troop="crpg_character_355"
+<MPClassDivision id="crpg_captain_division_355"
+                   hero="crpg_captain_355"
+                   troop="crpg_captain_355"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8166,9 +8166,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_356"
-                   hero="crpg_character_356"
-                   troop="crpg_character_356"
+<MPClassDivision id="crpg_captain_division_356"
+                   hero="crpg_captain_356"
+                   troop="crpg_captain_356"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8189,9 +8189,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_357"
-                   hero="crpg_character_357"
-                   troop="crpg_character_357"
+<MPClassDivision id="crpg_captain_division_357"
+                   hero="crpg_captain_357"
+                   troop="crpg_captain_357"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8212,9 +8212,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_358"
-                   hero="crpg_character_358"
-                   troop="crpg_character_358"
+<MPClassDivision id="crpg_captain_division_358"
+                   hero="crpg_captain_358"
+                   troop="crpg_captain_358"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8235,9 +8235,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_359"
-                   hero="crpg_character_359"
-                   troop="crpg_character_359"
+<MPClassDivision id="crpg_captain_division_359"
+                   hero="crpg_captain_359"
+                   troop="crpg_captain_359"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8258,9 +8258,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_360"
-                   hero="crpg_character_360"
-                   troop="crpg_character_360"
+<MPClassDivision id="crpg_captain_division_360"
+                   hero="crpg_captain_360"
+                   troop="crpg_captain_360"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8281,9 +8281,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_361"
-                   hero="crpg_character_361"
-                   troop="crpg_character_361"
+<MPClassDivision id="crpg_captain_division_361"
+                   hero="crpg_captain_361"
+                   troop="crpg_captain_361"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8304,9 +8304,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_362"
-                   hero="crpg_character_362"
-                   troop="crpg_character_362"
+<MPClassDivision id="crpg_captain_division_362"
+                   hero="crpg_captain_362"
+                   troop="crpg_captain_362"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8327,9 +8327,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_363"
-                   hero="crpg_character_363"
-                   troop="crpg_character_363"
+<MPClassDivision id="crpg_captain_division_363"
+                   hero="crpg_captain_363"
+                   troop="crpg_captain_363"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8350,9 +8350,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_364"
-                   hero="crpg_character_364"
-                   troop="crpg_character_364"
+<MPClassDivision id="crpg_captain_division_364"
+                   hero="crpg_captain_364"
+                   troop="crpg_captain_364"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8373,9 +8373,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_365"
-                   hero="crpg_character_365"
-                   troop="crpg_character_365"
+<MPClassDivision id="crpg_captain_division_365"
+                   hero="crpg_captain_365"
+                   troop="crpg_captain_365"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8396,9 +8396,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_366"
-                   hero="crpg_character_366"
-                   troop="crpg_character_366"
+<MPClassDivision id="crpg_captain_division_366"
+                   hero="crpg_captain_366"
+                   troop="crpg_captain_366"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8419,9 +8419,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_367"
-                   hero="crpg_character_367"
-                   troop="crpg_character_367"
+<MPClassDivision id="crpg_captain_division_367"
+                   hero="crpg_captain_367"
+                   troop="crpg_captain_367"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8442,9 +8442,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_368"
-                   hero="crpg_character_368"
-                   troop="crpg_character_368"
+<MPClassDivision id="crpg_captain_division_368"
+                   hero="crpg_captain_368"
+                   troop="crpg_captain_368"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8465,9 +8465,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_369"
-                   hero="crpg_character_369"
-                   troop="crpg_character_369"
+<MPClassDivision id="crpg_captain_division_369"
+                   hero="crpg_captain_369"
+                   troop="crpg_captain_369"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8488,9 +8488,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_370"
-                   hero="crpg_character_370"
-                   troop="crpg_character_370"
+<MPClassDivision id="crpg_captain_division_370"
+                   hero="crpg_captain_370"
+                   troop="crpg_captain_370"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8511,9 +8511,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_371"
-                   hero="crpg_character_371"
-                   troop="crpg_character_371"
+<MPClassDivision id="crpg_captain_division_371"
+                   hero="crpg_captain_371"
+                   troop="crpg_captain_371"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8534,9 +8534,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_372"
-                   hero="crpg_character_372"
-                   troop="crpg_character_372"
+<MPClassDivision id="crpg_captain_division_372"
+                   hero="crpg_captain_372"
+                   troop="crpg_captain_372"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8557,9 +8557,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_373"
-                   hero="crpg_character_373"
-                   troop="crpg_character_373"
+<MPClassDivision id="crpg_captain_division_373"
+                   hero="crpg_captain_373"
+                   troop="crpg_captain_373"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8580,9 +8580,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_374"
-                   hero="crpg_character_374"
-                   troop="crpg_character_374"
+<MPClassDivision id="crpg_captain_division_374"
+                   hero="crpg_captain_374"
+                   troop="crpg_captain_374"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8603,9 +8603,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_375"
-                   hero="crpg_character_375"
-                   troop="crpg_character_375"
+<MPClassDivision id="crpg_captain_division_375"
+                   hero="crpg_captain_375"
+                   troop="crpg_captain_375"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8626,9 +8626,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_376"
-                   hero="crpg_character_376"
-                   troop="crpg_character_376"
+<MPClassDivision id="crpg_captain_division_376"
+                   hero="crpg_captain_376"
+                   troop="crpg_captain_376"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8649,9 +8649,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_377"
-                   hero="crpg_character_377"
-                   troop="crpg_character_377"
+<MPClassDivision id="crpg_captain_division_377"
+                   hero="crpg_captain_377"
+                   troop="crpg_captain_377"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8672,9 +8672,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_378"
-                   hero="crpg_character_378"
-                   troop="crpg_character_378"
+<MPClassDivision id="crpg_captain_division_378"
+                   hero="crpg_captain_378"
+                   troop="crpg_captain_378"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8695,9 +8695,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_379"
-                   hero="crpg_character_379"
-                   troop="crpg_character_379"
+<MPClassDivision id="crpg_captain_division_379"
+                   hero="crpg_captain_379"
+                   troop="crpg_captain_379"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8718,9 +8718,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_380"
-                   hero="crpg_character_380"
-                   troop="crpg_character_380"
+<MPClassDivision id="crpg_captain_division_380"
+                   hero="crpg_captain_380"
+                   troop="crpg_captain_380"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8741,9 +8741,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_381"
-                   hero="crpg_character_381"
-                   troop="crpg_character_381"
+<MPClassDivision id="crpg_captain_division_381"
+                   hero="crpg_captain_381"
+                   troop="crpg_captain_381"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8764,9 +8764,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_382"
-                   hero="crpg_character_382"
-                   troop="crpg_character_382"
+<MPClassDivision id="crpg_captain_division_382"
+                   hero="crpg_captain_382"
+                   troop="crpg_captain_382"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8787,9 +8787,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_383"
-                   hero="crpg_character_383"
-                   troop="crpg_character_383"
+<MPClassDivision id="crpg_captain_division_383"
+                   hero="crpg_captain_383"
+                   troop="crpg_captain_383"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8810,9 +8810,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_384"
-                   hero="crpg_character_384"
-                   troop="crpg_character_384"
+<MPClassDivision id="crpg_captain_division_384"
+                   hero="crpg_captain_384"
+                   troop="crpg_captain_384"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8833,9 +8833,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_385"
-                   hero="crpg_character_385"
-                   troop="crpg_character_385"
+<MPClassDivision id="crpg_captain_division_385"
+                   hero="crpg_captain_385"
+                   troop="crpg_captain_385"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8856,9 +8856,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_386"
-                   hero="crpg_character_386"
-                   troop="crpg_character_386"
+<MPClassDivision id="crpg_captain_division_386"
+                   hero="crpg_captain_386"
+                   troop="crpg_captain_386"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8879,9 +8879,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_387"
-                   hero="crpg_character_387"
-                   troop="crpg_character_387"
+<MPClassDivision id="crpg_captain_division_387"
+                   hero="crpg_captain_387"
+                   troop="crpg_captain_387"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8902,9 +8902,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_388"
-                   hero="crpg_character_388"
-                   troop="crpg_character_388"
+<MPClassDivision id="crpg_captain_division_388"
+                   hero="crpg_captain_388"
+                   troop="crpg_captain_388"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8925,9 +8925,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_389"
-                   hero="crpg_character_389"
-                   troop="crpg_character_389"
+<MPClassDivision id="crpg_captain_division_389"
+                   hero="crpg_captain_389"
+                   troop="crpg_captain_389"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8948,9 +8948,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_390"
-                   hero="crpg_character_390"
-                   troop="crpg_character_390"
+<MPClassDivision id="crpg_captain_division_390"
+                   hero="crpg_captain_390"
+                   troop="crpg_captain_390"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8971,9 +8971,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_391"
-                   hero="crpg_character_391"
-                   troop="crpg_character_391"
+<MPClassDivision id="crpg_captain_division_391"
+                   hero="crpg_captain_391"
+                   troop="crpg_captain_391"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -8994,9 +8994,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_392"
-                   hero="crpg_character_392"
-                   troop="crpg_character_392"
+<MPClassDivision id="crpg_captain_division_392"
+                   hero="crpg_captain_392"
+                   troop="crpg_captain_392"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9017,9 +9017,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_393"
-                   hero="crpg_character_393"
-                   troop="crpg_character_393"
+<MPClassDivision id="crpg_captain_division_393"
+                   hero="crpg_captain_393"
+                   troop="crpg_captain_393"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9040,9 +9040,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_394"
-                   hero="crpg_character_394"
-                   troop="crpg_character_394"
+<MPClassDivision id="crpg_captain_division_394"
+                   hero="crpg_captain_394"
+                   troop="crpg_captain_394"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9063,9 +9063,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_395"
-                   hero="crpg_character_395"
-                   troop="crpg_character_395"
+<MPClassDivision id="crpg_captain_division_395"
+                   hero="crpg_captain_395"
+                   troop="crpg_captain_395"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9086,9 +9086,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_396"
-                   hero="crpg_character_396"
-                   troop="crpg_character_396"
+<MPClassDivision id="crpg_captain_division_396"
+                   hero="crpg_captain_396"
+                   troop="crpg_captain_396"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9109,9 +9109,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_397"
-                   hero="crpg_character_397"
-                   troop="crpg_character_397"
+<MPClassDivision id="crpg_captain_division_397"
+                   hero="crpg_captain_397"
+                   troop="crpg_captain_397"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9132,9 +9132,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_398"
-                   hero="crpg_character_398"
-                   troop="crpg_character_398"
+<MPClassDivision id="crpg_captain_division_398"
+                   hero="crpg_captain_398"
+                   troop="crpg_captain_398"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9155,9 +9155,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_399"
-                   hero="crpg_character_399"
-                   troop="crpg_character_399"
+<MPClassDivision id="crpg_captain_division_399"
+                   hero="crpg_captain_399"
+                   troop="crpg_captain_399"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9178,9 +9178,9 @@
       </Perk>
     </Perks>
 </MPClassDivision>
-<MPClassDivision id="crpg_class_division_400"
-                   hero="crpg_character_400"
-                   troop="crpg_character_400"
+<MPClassDivision id="crpg_captain_division_400"
+                   hero="crpg_captain_400"
+                   troop="crpg_captain_400"
                    hero_idle_anim="act_vlandia_mp_sergeant_idle"
                    troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
                    multiplier="0"
@@ -9200,5 +9200,9206 @@
             perk_list="1">
       </Perk>
     </Perks>
+</MPClassDivision>
+  
+<MPClassDivision id="crpg_captain_bot_division_1"
+                  hero="crpg_captain_bot_1"
+                  troop="crpg_captain_bot_1"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_2"
+                  hero="crpg_captain_bot_2"
+                  troop="crpg_captain_bot_2"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_3"
+                  hero="crpg_captain_bot_3"
+                  troop="crpg_captain_bot_3"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_4"
+                  hero="crpg_captain_bot_4"
+                  troop="crpg_captain_bot_4"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_5"
+                  hero="crpg_captain_bot_5"
+                  troop="crpg_captain_bot_5"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_6"
+                  hero="crpg_captain_bot_6"
+                  troop="crpg_captain_bot_6"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_7"
+                  hero="crpg_captain_bot_7"
+                  troop="crpg_captain_bot_7"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_8"
+                  hero="crpg_captain_bot_8"
+                  troop="crpg_captain_bot_8"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_9"
+                  hero="crpg_captain_bot_9"
+                  troop="crpg_captain_bot_9"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_10"
+                  hero="crpg_captain_bot_10"
+                  troop="crpg_captain_bot_10"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_11"
+                  hero="crpg_captain_bot_11"
+                  troop="crpg_captain_bot_11"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_12"
+                  hero="crpg_captain_bot_12"
+                  troop="crpg_captain_bot_12"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_13"
+                  hero="crpg_captain_bot_13"
+                  troop="crpg_captain_bot_13"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_14"
+                  hero="crpg_captain_bot_14"
+                  troop="crpg_captain_bot_14"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_15"
+                  hero="crpg_captain_bot_15"
+                  troop="crpg_captain_bot_15"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_16"
+                  hero="crpg_captain_bot_16"
+                  troop="crpg_captain_bot_16"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_17"
+                  hero="crpg_captain_bot_17"
+                  troop="crpg_captain_bot_17"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_18"
+                  hero="crpg_captain_bot_18"
+                  troop="crpg_captain_bot_18"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_19"
+                  hero="crpg_captain_bot_19"
+                  troop="crpg_captain_bot_19"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_20"
+                  hero="crpg_captain_bot_20"
+                  troop="crpg_captain_bot_20"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_21"
+                  hero="crpg_captain_bot_21"
+                  troop="crpg_captain_bot_21"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_22"
+                  hero="crpg_captain_bot_22"
+                  troop="crpg_captain_bot_22"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_23"
+                  hero="crpg_captain_bot_23"
+                  troop="crpg_captain_bot_23"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_24"
+                  hero="crpg_captain_bot_24"
+                  troop="crpg_captain_bot_24"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_25"
+                  hero="crpg_captain_bot_25"
+                  troop="crpg_captain_bot_25"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_26"
+                  hero="crpg_captain_bot_26"
+                  troop="crpg_captain_bot_26"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_27"
+                  hero="crpg_captain_bot_27"
+                  troop="crpg_captain_bot_27"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_28"
+                  hero="crpg_captain_bot_28"
+                  troop="crpg_captain_bot_28"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_29"
+                  hero="crpg_captain_bot_29"
+                  troop="crpg_captain_bot_29"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_30"
+                  hero="crpg_captain_bot_30"
+                  troop="crpg_captain_bot_30"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_31"
+                  hero="crpg_captain_bot_31"
+                  troop="crpg_captain_bot_31"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_32"
+                  hero="crpg_captain_bot_32"
+                  troop="crpg_captain_bot_32"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_33"
+                  hero="crpg_captain_bot_33"
+                  troop="crpg_captain_bot_33"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_34"
+                  hero="crpg_captain_bot_34"
+                  troop="crpg_captain_bot_34"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_35"
+                  hero="crpg_captain_bot_35"
+                  troop="crpg_captain_bot_35"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_36"
+                  hero="crpg_captain_bot_36"
+                  troop="crpg_captain_bot_36"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_37"
+                  hero="crpg_captain_bot_37"
+                  troop="crpg_captain_bot_37"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_38"
+                  hero="crpg_captain_bot_38"
+                  troop="crpg_captain_bot_38"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_39"
+                  hero="crpg_captain_bot_39"
+                  troop="crpg_captain_bot_39"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_40"
+                  hero="crpg_captain_bot_40"
+                  troop="crpg_captain_bot_40"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_41"
+                  hero="crpg_captain_bot_41"
+                  troop="crpg_captain_bot_41"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_42"
+                  hero="crpg_captain_bot_42"
+                  troop="crpg_captain_bot_42"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_43"
+                  hero="crpg_captain_bot_43"
+                  troop="crpg_captain_bot_43"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_44"
+                  hero="crpg_captain_bot_44"
+                  troop="crpg_captain_bot_44"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_45"
+                  hero="crpg_captain_bot_45"
+                  troop="crpg_captain_bot_45"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_46"
+                  hero="crpg_captain_bot_46"
+                  troop="crpg_captain_bot_46"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_47"
+                  hero="crpg_captain_bot_47"
+                  troop="crpg_captain_bot_47"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_48"
+                  hero="crpg_captain_bot_48"
+                  troop="crpg_captain_bot_48"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_49"
+                  hero="crpg_captain_bot_49"
+                  troop="crpg_captain_bot_49"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_50"
+                  hero="crpg_captain_bot_50"
+                  troop="crpg_captain_bot_50"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_51"
+                  hero="crpg_captain_bot_51"
+                  troop="crpg_captain_bot_51"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_52"
+                  hero="crpg_captain_bot_52"
+                  troop="crpg_captain_bot_52"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_53"
+                  hero="crpg_captain_bot_53"
+                  troop="crpg_captain_bot_53"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_54"
+                  hero="crpg_captain_bot_54"
+                  troop="crpg_captain_bot_54"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_55"
+                  hero="crpg_captain_bot_55"
+                  troop="crpg_captain_bot_55"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_56"
+                  hero="crpg_captain_bot_56"
+                  troop="crpg_captain_bot_56"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_57"
+                  hero="crpg_captain_bot_57"
+                  troop="crpg_captain_bot_57"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_58"
+                  hero="crpg_captain_bot_58"
+                  troop="crpg_captain_bot_58"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_59"
+                  hero="crpg_captain_bot_59"
+                  troop="crpg_captain_bot_59"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_60"
+                  hero="crpg_captain_bot_60"
+                  troop="crpg_captain_bot_60"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_61"
+                  hero="crpg_captain_bot_61"
+                  troop="crpg_captain_bot_61"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_62"
+                  hero="crpg_captain_bot_62"
+                  troop="crpg_captain_bot_62"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_63"
+                  hero="crpg_captain_bot_63"
+                  troop="crpg_captain_bot_63"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_64"
+                  hero="crpg_captain_bot_64"
+                  troop="crpg_captain_bot_64"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_65"
+                  hero="crpg_captain_bot_65"
+                  troop="crpg_captain_bot_65"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_66"
+                  hero="crpg_captain_bot_66"
+                  troop="crpg_captain_bot_66"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_67"
+                  hero="crpg_captain_bot_67"
+                  troop="crpg_captain_bot_67"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_68"
+                  hero="crpg_captain_bot_68"
+                  troop="crpg_captain_bot_68"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_69"
+                  hero="crpg_captain_bot_69"
+                  troop="crpg_captain_bot_69"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_70"
+                  hero="crpg_captain_bot_70"
+                  troop="crpg_captain_bot_70"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_71"
+                  hero="crpg_captain_bot_71"
+                  troop="crpg_captain_bot_71"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_72"
+                  hero="crpg_captain_bot_72"
+                  troop="crpg_captain_bot_72"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_73"
+                  hero="crpg_captain_bot_73"
+                  troop="crpg_captain_bot_73"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_74"
+                  hero="crpg_captain_bot_74"
+                  troop="crpg_captain_bot_74"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_75"
+                  hero="crpg_captain_bot_75"
+                  troop="crpg_captain_bot_75"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_76"
+                  hero="crpg_captain_bot_76"
+                  troop="crpg_captain_bot_76"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_77"
+                  hero="crpg_captain_bot_77"
+                  troop="crpg_captain_bot_77"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_78"
+                  hero="crpg_captain_bot_78"
+                  troop="crpg_captain_bot_78"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_79"
+                  hero="crpg_captain_bot_79"
+                  troop="crpg_captain_bot_79"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_80"
+                  hero="crpg_captain_bot_80"
+                  troop="crpg_captain_bot_80"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_81"
+                  hero="crpg_captain_bot_81"
+                  troop="crpg_captain_bot_81"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_82"
+                  hero="crpg_captain_bot_82"
+                  troop="crpg_captain_bot_82"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_83"
+                  hero="crpg_captain_bot_83"
+                  troop="crpg_captain_bot_83"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_84"
+                  hero="crpg_captain_bot_84"
+                  troop="crpg_captain_bot_84"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_85"
+                  hero="crpg_captain_bot_85"
+                  troop="crpg_captain_bot_85"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_86"
+                  hero="crpg_captain_bot_86"
+                  troop="crpg_captain_bot_86"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_87"
+                  hero="crpg_captain_bot_87"
+                  troop="crpg_captain_bot_87"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_88"
+                  hero="crpg_captain_bot_88"
+                  troop="crpg_captain_bot_88"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_89"
+                  hero="crpg_captain_bot_89"
+                  troop="crpg_captain_bot_89"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_90"
+                  hero="crpg_captain_bot_90"
+                  troop="crpg_captain_bot_90"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_91"
+                  hero="crpg_captain_bot_91"
+                  troop="crpg_captain_bot_91"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_92"
+                  hero="crpg_captain_bot_92"
+                  troop="crpg_captain_bot_92"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_93"
+                  hero="crpg_captain_bot_93"
+                  troop="crpg_captain_bot_93"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_94"
+                  hero="crpg_captain_bot_94"
+                  troop="crpg_captain_bot_94"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_95"
+                  hero="crpg_captain_bot_95"
+                  troop="crpg_captain_bot_95"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_96"
+                  hero="crpg_captain_bot_96"
+                  troop="crpg_captain_bot_96"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_97"
+                  hero="crpg_captain_bot_97"
+                  troop="crpg_captain_bot_97"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_98"
+                  hero="crpg_captain_bot_98"
+                  troop="crpg_captain_bot_98"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_99"
+                  hero="crpg_captain_bot_99"
+                  troop="crpg_captain_bot_99"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_100"
+                  hero="crpg_captain_bot_100"
+                  troop="crpg_captain_bot_100"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_101"
+                  hero="crpg_captain_bot_101"
+                  troop="crpg_captain_bot_101"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_102"
+                  hero="crpg_captain_bot_102"
+                  troop="crpg_captain_bot_102"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_103"
+                  hero="crpg_captain_bot_103"
+                  troop="crpg_captain_bot_103"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_104"
+                  hero="crpg_captain_bot_104"
+                  troop="crpg_captain_bot_104"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_105"
+                  hero="crpg_captain_bot_105"
+                  troop="crpg_captain_bot_105"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_106"
+                  hero="crpg_captain_bot_106"
+                  troop="crpg_captain_bot_106"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_107"
+                  hero="crpg_captain_bot_107"
+                  troop="crpg_captain_bot_107"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_108"
+                  hero="crpg_captain_bot_108"
+                  troop="crpg_captain_bot_108"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_109"
+                  hero="crpg_captain_bot_109"
+                  troop="crpg_captain_bot_109"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_110"
+                  hero="crpg_captain_bot_110"
+                  troop="crpg_captain_bot_110"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_111"
+                  hero="crpg_captain_bot_111"
+                  troop="crpg_captain_bot_111"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_112"
+                  hero="crpg_captain_bot_112"
+                  troop="crpg_captain_bot_112"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_113"
+                  hero="crpg_captain_bot_113"
+                  troop="crpg_captain_bot_113"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_114"
+                  hero="crpg_captain_bot_114"
+                  troop="crpg_captain_bot_114"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_115"
+                  hero="crpg_captain_bot_115"
+                  troop="crpg_captain_bot_115"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_116"
+                  hero="crpg_captain_bot_116"
+                  troop="crpg_captain_bot_116"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_117"
+                  hero="crpg_captain_bot_117"
+                  troop="crpg_captain_bot_117"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_118"
+                  hero="crpg_captain_bot_118"
+                  troop="crpg_captain_bot_118"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_119"
+                  hero="crpg_captain_bot_119"
+                  troop="crpg_captain_bot_119"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_120"
+                  hero="crpg_captain_bot_120"
+                  troop="crpg_captain_bot_120"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_121"
+                  hero="crpg_captain_bot_121"
+                  troop="crpg_captain_bot_121"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_122"
+                  hero="crpg_captain_bot_122"
+                  troop="crpg_captain_bot_122"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_123"
+                  hero="crpg_captain_bot_123"
+                  troop="crpg_captain_bot_123"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_124"
+                  hero="crpg_captain_bot_124"
+                  troop="crpg_captain_bot_124"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_125"
+                  hero="crpg_captain_bot_125"
+                  troop="crpg_captain_bot_125"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_126"
+                  hero="crpg_captain_bot_126"
+                  troop="crpg_captain_bot_126"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_127"
+                  hero="crpg_captain_bot_127"
+                  troop="crpg_captain_bot_127"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_128"
+                  hero="crpg_captain_bot_128"
+                  troop="crpg_captain_bot_128"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_129"
+                  hero="crpg_captain_bot_129"
+                  troop="crpg_captain_bot_129"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_130"
+                  hero="crpg_captain_bot_130"
+                  troop="crpg_captain_bot_130"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_131"
+                  hero="crpg_captain_bot_131"
+                  troop="crpg_captain_bot_131"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_132"
+                  hero="crpg_captain_bot_132"
+                  troop="crpg_captain_bot_132"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_133"
+                  hero="crpg_captain_bot_133"
+                  troop="crpg_captain_bot_133"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_134"
+                  hero="crpg_captain_bot_134"
+                  troop="crpg_captain_bot_134"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_135"
+                  hero="crpg_captain_bot_135"
+                  troop="crpg_captain_bot_135"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_136"
+                  hero="crpg_captain_bot_136"
+                  troop="crpg_captain_bot_136"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_137"
+                  hero="crpg_captain_bot_137"
+                  troop="crpg_captain_bot_137"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_138"
+                  hero="crpg_captain_bot_138"
+                  troop="crpg_captain_bot_138"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_139"
+                  hero="crpg_captain_bot_139"
+                  troop="crpg_captain_bot_139"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_140"
+                  hero="crpg_captain_bot_140"
+                  troop="crpg_captain_bot_140"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_141"
+                  hero="crpg_captain_bot_141"
+                  troop="crpg_captain_bot_141"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_142"
+                  hero="crpg_captain_bot_142"
+                  troop="crpg_captain_bot_142"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_143"
+                  hero="crpg_captain_bot_143"
+                  troop="crpg_captain_bot_143"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_144"
+                  hero="crpg_captain_bot_144"
+                  troop="crpg_captain_bot_144"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_145"
+                  hero="crpg_captain_bot_145"
+                  troop="crpg_captain_bot_145"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_146"
+                  hero="crpg_captain_bot_146"
+                  troop="crpg_captain_bot_146"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_147"
+                  hero="crpg_captain_bot_147"
+                  troop="crpg_captain_bot_147"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_148"
+                  hero="crpg_captain_bot_148"
+                  troop="crpg_captain_bot_148"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_149"
+                  hero="crpg_captain_bot_149"
+                  troop="crpg_captain_bot_149"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_150"
+                  hero="crpg_captain_bot_150"
+                  troop="crpg_captain_bot_150"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_151"
+                  hero="crpg_captain_bot_151"
+                  troop="crpg_captain_bot_151"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_152"
+                  hero="crpg_captain_bot_152"
+                  troop="crpg_captain_bot_152"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_153"
+                  hero="crpg_captain_bot_153"
+                  troop="crpg_captain_bot_153"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_154"
+                  hero="crpg_captain_bot_154"
+                  troop="crpg_captain_bot_154"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_155"
+                  hero="crpg_captain_bot_155"
+                  troop="crpg_captain_bot_155"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_156"
+                  hero="crpg_captain_bot_156"
+                  troop="crpg_captain_bot_156"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_157"
+                  hero="crpg_captain_bot_157"
+                  troop="crpg_captain_bot_157"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_158"
+                  hero="crpg_captain_bot_158"
+                  troop="crpg_captain_bot_158"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_159"
+                  hero="crpg_captain_bot_159"
+                  troop="crpg_captain_bot_159"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_160"
+                  hero="crpg_captain_bot_160"
+                  troop="crpg_captain_bot_160"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_161"
+                  hero="crpg_captain_bot_161"
+                  troop="crpg_captain_bot_161"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_162"
+                  hero="crpg_captain_bot_162"
+                  troop="crpg_captain_bot_162"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_163"
+                  hero="crpg_captain_bot_163"
+                  troop="crpg_captain_bot_163"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_164"
+                  hero="crpg_captain_bot_164"
+                  troop="crpg_captain_bot_164"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_165"
+                  hero="crpg_captain_bot_165"
+                  troop="crpg_captain_bot_165"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_166"
+                  hero="crpg_captain_bot_166"
+                  troop="crpg_captain_bot_166"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_167"
+                  hero="crpg_captain_bot_167"
+                  troop="crpg_captain_bot_167"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_168"
+                  hero="crpg_captain_bot_168"
+                  troop="crpg_captain_bot_168"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_169"
+                  hero="crpg_captain_bot_169"
+                  troop="crpg_captain_bot_169"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_170"
+                  hero="crpg_captain_bot_170"
+                  troop="crpg_captain_bot_170"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_171"
+                  hero="crpg_captain_bot_171"
+                  troop="crpg_captain_bot_171"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_172"
+                  hero="crpg_captain_bot_172"
+                  troop="crpg_captain_bot_172"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_173"
+                  hero="crpg_captain_bot_173"
+                  troop="crpg_captain_bot_173"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_174"
+                  hero="crpg_captain_bot_174"
+                  troop="crpg_captain_bot_174"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_175"
+                  hero="crpg_captain_bot_175"
+                  troop="crpg_captain_bot_175"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_176"
+                  hero="crpg_captain_bot_176"
+                  troop="crpg_captain_bot_176"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_177"
+                  hero="crpg_captain_bot_177"
+                  troop="crpg_captain_bot_177"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_178"
+                  hero="crpg_captain_bot_178"
+                  troop="crpg_captain_bot_178"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_179"
+                  hero="crpg_captain_bot_179"
+                  troop="crpg_captain_bot_179"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_180"
+                  hero="crpg_captain_bot_180"
+                  troop="crpg_captain_bot_180"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_181"
+                  hero="crpg_captain_bot_181"
+                  troop="crpg_captain_bot_181"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_182"
+                  hero="crpg_captain_bot_182"
+                  troop="crpg_captain_bot_182"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_183"
+                  hero="crpg_captain_bot_183"
+                  troop="crpg_captain_bot_183"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_184"
+                  hero="crpg_captain_bot_184"
+                  troop="crpg_captain_bot_184"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_185"
+                  hero="crpg_captain_bot_185"
+                  troop="crpg_captain_bot_185"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_186"
+                  hero="crpg_captain_bot_186"
+                  troop="crpg_captain_bot_186"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_187"
+                  hero="crpg_captain_bot_187"
+                  troop="crpg_captain_bot_187"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_188"
+                  hero="crpg_captain_bot_188"
+                  troop="crpg_captain_bot_188"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_189"
+                  hero="crpg_captain_bot_189"
+                  troop="crpg_captain_bot_189"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_190"
+                  hero="crpg_captain_bot_190"
+                  troop="crpg_captain_bot_190"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_191"
+                  hero="crpg_captain_bot_191"
+                  troop="crpg_captain_bot_191"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_192"
+                  hero="crpg_captain_bot_192"
+                  troop="crpg_captain_bot_192"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_193"
+                  hero="crpg_captain_bot_193"
+                  troop="crpg_captain_bot_193"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_194"
+                  hero="crpg_captain_bot_194"
+                  troop="crpg_captain_bot_194"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_195"
+                  hero="crpg_captain_bot_195"
+                  troop="crpg_captain_bot_195"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_196"
+                  hero="crpg_captain_bot_196"
+                  troop="crpg_captain_bot_196"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_197"
+                  hero="crpg_captain_bot_197"
+                  troop="crpg_captain_bot_197"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_198"
+                  hero="crpg_captain_bot_198"
+                  troop="crpg_captain_bot_198"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_199"
+                  hero="crpg_captain_bot_199"
+                  troop="crpg_captain_bot_199"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_200"
+                  hero="crpg_captain_bot_200"
+                  troop="crpg_captain_bot_200"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_201"
+                  hero="crpg_captain_bot_201"
+                  troop="crpg_captain_bot_201"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_202"
+                  hero="crpg_captain_bot_202"
+                  troop="crpg_captain_bot_202"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_203"
+                  hero="crpg_captain_bot_203"
+                  troop="crpg_captain_bot_203"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_204"
+                  hero="crpg_captain_bot_204"
+                  troop="crpg_captain_bot_204"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_205"
+                  hero="crpg_captain_bot_205"
+                  troop="crpg_captain_bot_205"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_206"
+                  hero="crpg_captain_bot_206"
+                  troop="crpg_captain_bot_206"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_207"
+                  hero="crpg_captain_bot_207"
+                  troop="crpg_captain_bot_207"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_208"
+                  hero="crpg_captain_bot_208"
+                  troop="crpg_captain_bot_208"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_209"
+                  hero="crpg_captain_bot_209"
+                  troop="crpg_captain_bot_209"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_210"
+                  hero="crpg_captain_bot_210"
+                  troop="crpg_captain_bot_210"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_211"
+                  hero="crpg_captain_bot_211"
+                  troop="crpg_captain_bot_211"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_212"
+                  hero="crpg_captain_bot_212"
+                  troop="crpg_captain_bot_212"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_213"
+                  hero="crpg_captain_bot_213"
+                  troop="crpg_captain_bot_213"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_214"
+                  hero="crpg_captain_bot_214"
+                  troop="crpg_captain_bot_214"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_215"
+                  hero="crpg_captain_bot_215"
+                  troop="crpg_captain_bot_215"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_216"
+                  hero="crpg_captain_bot_216"
+                  troop="crpg_captain_bot_216"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_217"
+                  hero="crpg_captain_bot_217"
+                  troop="crpg_captain_bot_217"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_218"
+                  hero="crpg_captain_bot_218"
+                  troop="crpg_captain_bot_218"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_219"
+                  hero="crpg_captain_bot_219"
+                  troop="crpg_captain_bot_219"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_220"
+                  hero="crpg_captain_bot_220"
+                  troop="crpg_captain_bot_220"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_221"
+                  hero="crpg_captain_bot_221"
+                  troop="crpg_captain_bot_221"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_222"
+                  hero="crpg_captain_bot_222"
+                  troop="crpg_captain_bot_222"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_223"
+                  hero="crpg_captain_bot_223"
+                  troop="crpg_captain_bot_223"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_224"
+                  hero="crpg_captain_bot_224"
+                  troop="crpg_captain_bot_224"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_225"
+                  hero="crpg_captain_bot_225"
+                  troop="crpg_captain_bot_225"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_226"
+                  hero="crpg_captain_bot_226"
+                  troop="crpg_captain_bot_226"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_227"
+                  hero="crpg_captain_bot_227"
+                  troop="crpg_captain_bot_227"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_228"
+                  hero="crpg_captain_bot_228"
+                  troop="crpg_captain_bot_228"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_229"
+                  hero="crpg_captain_bot_229"
+                  troop="crpg_captain_bot_229"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_230"
+                  hero="crpg_captain_bot_230"
+                  troop="crpg_captain_bot_230"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_231"
+                  hero="crpg_captain_bot_231"
+                  troop="crpg_captain_bot_231"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_232"
+                  hero="crpg_captain_bot_232"
+                  troop="crpg_captain_bot_232"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_233"
+                  hero="crpg_captain_bot_233"
+                  troop="crpg_captain_bot_233"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_234"
+                  hero="crpg_captain_bot_234"
+                  troop="crpg_captain_bot_234"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_235"
+                  hero="crpg_captain_bot_235"
+                  troop="crpg_captain_bot_235"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_236"
+                  hero="crpg_captain_bot_236"
+                  troop="crpg_captain_bot_236"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_237"
+                  hero="crpg_captain_bot_237"
+                  troop="crpg_captain_bot_237"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_238"
+                  hero="crpg_captain_bot_238"
+                  troop="crpg_captain_bot_238"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_239"
+                  hero="crpg_captain_bot_239"
+                  troop="crpg_captain_bot_239"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_240"
+                  hero="crpg_captain_bot_240"
+                  troop="crpg_captain_bot_240"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_241"
+                  hero="crpg_captain_bot_241"
+                  troop="crpg_captain_bot_241"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_242"
+                  hero="crpg_captain_bot_242"
+                  troop="crpg_captain_bot_242"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_243"
+                  hero="crpg_captain_bot_243"
+                  troop="crpg_captain_bot_243"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_244"
+                  hero="crpg_captain_bot_244"
+                  troop="crpg_captain_bot_244"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_245"
+                  hero="crpg_captain_bot_245"
+                  troop="crpg_captain_bot_245"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_246"
+                  hero="crpg_captain_bot_246"
+                  troop="crpg_captain_bot_246"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_247"
+                  hero="crpg_captain_bot_247"
+                  troop="crpg_captain_bot_247"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_248"
+                  hero="crpg_captain_bot_248"
+                  troop="crpg_captain_bot_248"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_249"
+                  hero="crpg_captain_bot_249"
+                  troop="crpg_captain_bot_249"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_250"
+                  hero="crpg_captain_bot_250"
+                  troop="crpg_captain_bot_250"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_251"
+                  hero="crpg_captain_bot_251"
+                  troop="crpg_captain_bot_251"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_252"
+                  hero="crpg_captain_bot_252"
+                  troop="crpg_captain_bot_252"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_253"
+                  hero="crpg_captain_bot_253"
+                  troop="crpg_captain_bot_253"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_254"
+                  hero="crpg_captain_bot_254"
+                  troop="crpg_captain_bot_254"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_255"
+                  hero="crpg_captain_bot_255"
+                  troop="crpg_captain_bot_255"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_256"
+                  hero="crpg_captain_bot_256"
+                  troop="crpg_captain_bot_256"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_257"
+                  hero="crpg_captain_bot_257"
+                  troop="crpg_captain_bot_257"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_258"
+                  hero="crpg_captain_bot_258"
+                  troop="crpg_captain_bot_258"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_259"
+                  hero="crpg_captain_bot_259"
+                  troop="crpg_captain_bot_259"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_260"
+                  hero="crpg_captain_bot_260"
+                  troop="crpg_captain_bot_260"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_261"
+                  hero="crpg_captain_bot_261"
+                  troop="crpg_captain_bot_261"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_262"
+                  hero="crpg_captain_bot_262"
+                  troop="crpg_captain_bot_262"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_263"
+                  hero="crpg_captain_bot_263"
+                  troop="crpg_captain_bot_263"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_264"
+                  hero="crpg_captain_bot_264"
+                  troop="crpg_captain_bot_264"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_265"
+                  hero="crpg_captain_bot_265"
+                  troop="crpg_captain_bot_265"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_266"
+                  hero="crpg_captain_bot_266"
+                  troop="crpg_captain_bot_266"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_267"
+                  hero="crpg_captain_bot_267"
+                  troop="crpg_captain_bot_267"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_268"
+                  hero="crpg_captain_bot_268"
+                  troop="crpg_captain_bot_268"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_269"
+                  hero="crpg_captain_bot_269"
+                  troop="crpg_captain_bot_269"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_270"
+                  hero="crpg_captain_bot_270"
+                  troop="crpg_captain_bot_270"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_271"
+                  hero="crpg_captain_bot_271"
+                  troop="crpg_captain_bot_271"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_272"
+                  hero="crpg_captain_bot_272"
+                  troop="crpg_captain_bot_272"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_273"
+                  hero="crpg_captain_bot_273"
+                  troop="crpg_captain_bot_273"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_274"
+                  hero="crpg_captain_bot_274"
+                  troop="crpg_captain_bot_274"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_275"
+                  hero="crpg_captain_bot_275"
+                  troop="crpg_captain_bot_275"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_276"
+                  hero="crpg_captain_bot_276"
+                  troop="crpg_captain_bot_276"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_277"
+                  hero="crpg_captain_bot_277"
+                  troop="crpg_captain_bot_277"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_278"
+                  hero="crpg_captain_bot_278"
+                  troop="crpg_captain_bot_278"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_279"
+                  hero="crpg_captain_bot_279"
+                  troop="crpg_captain_bot_279"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_280"
+                  hero="crpg_captain_bot_280"
+                  troop="crpg_captain_bot_280"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_281"
+                  hero="crpg_captain_bot_281"
+                  troop="crpg_captain_bot_281"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_282"
+                  hero="crpg_captain_bot_282"
+                  troop="crpg_captain_bot_282"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_283"
+                  hero="crpg_captain_bot_283"
+                  troop="crpg_captain_bot_283"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_284"
+                  hero="crpg_captain_bot_284"
+                  troop="crpg_captain_bot_284"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_285"
+                  hero="crpg_captain_bot_285"
+                  troop="crpg_captain_bot_285"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_286"
+                  hero="crpg_captain_bot_286"
+                  troop="crpg_captain_bot_286"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_287"
+                  hero="crpg_captain_bot_287"
+                  troop="crpg_captain_bot_287"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_288"
+                  hero="crpg_captain_bot_288"
+                  troop="crpg_captain_bot_288"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_289"
+                  hero="crpg_captain_bot_289"
+                  troop="crpg_captain_bot_289"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_290"
+                  hero="crpg_captain_bot_290"
+                  troop="crpg_captain_bot_290"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_291"
+                  hero="crpg_captain_bot_291"
+                  troop="crpg_captain_bot_291"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_292"
+                  hero="crpg_captain_bot_292"
+                  troop="crpg_captain_bot_292"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_293"
+                  hero="crpg_captain_bot_293"
+                  troop="crpg_captain_bot_293"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_294"
+                  hero="crpg_captain_bot_294"
+                  troop="crpg_captain_bot_294"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_295"
+                  hero="crpg_captain_bot_295"
+                  troop="crpg_captain_bot_295"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_296"
+                  hero="crpg_captain_bot_296"
+                  troop="crpg_captain_bot_296"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_297"
+                  hero="crpg_captain_bot_297"
+                  troop="crpg_captain_bot_297"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_298"
+                  hero="crpg_captain_bot_298"
+                  troop="crpg_captain_bot_298"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_299"
+                  hero="crpg_captain_bot_299"
+                  troop="crpg_captain_bot_299"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_300"
+                  hero="crpg_captain_bot_300"
+                  troop="crpg_captain_bot_300"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_301"
+                  hero="crpg_captain_bot_301"
+                  troop="crpg_captain_bot_301"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_302"
+                  hero="crpg_captain_bot_302"
+                  troop="crpg_captain_bot_302"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_303"
+                  hero="crpg_captain_bot_303"
+                  troop="crpg_captain_bot_303"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_304"
+                  hero="crpg_captain_bot_304"
+                  troop="crpg_captain_bot_304"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_305"
+                  hero="crpg_captain_bot_305"
+                  troop="crpg_captain_bot_305"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_306"
+                  hero="crpg_captain_bot_306"
+                  troop="crpg_captain_bot_306"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_307"
+                  hero="crpg_captain_bot_307"
+                  troop="crpg_captain_bot_307"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_308"
+                  hero="crpg_captain_bot_308"
+                  troop="crpg_captain_bot_308"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_309"
+                  hero="crpg_captain_bot_309"
+                  troop="crpg_captain_bot_309"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_310"
+                  hero="crpg_captain_bot_310"
+                  troop="crpg_captain_bot_310"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_311"
+                  hero="crpg_captain_bot_311"
+                  troop="crpg_captain_bot_311"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_312"
+                  hero="crpg_captain_bot_312"
+                  troop="crpg_captain_bot_312"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_313"
+                  hero="crpg_captain_bot_313"
+                  troop="crpg_captain_bot_313"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_314"
+                  hero="crpg_captain_bot_314"
+                  troop="crpg_captain_bot_314"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_315"
+                  hero="crpg_captain_bot_315"
+                  troop="crpg_captain_bot_315"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_316"
+                  hero="crpg_captain_bot_316"
+                  troop="crpg_captain_bot_316"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_317"
+                  hero="crpg_captain_bot_317"
+                  troop="crpg_captain_bot_317"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_318"
+                  hero="crpg_captain_bot_318"
+                  troop="crpg_captain_bot_318"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_319"
+                  hero="crpg_captain_bot_319"
+                  troop="crpg_captain_bot_319"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_320"
+                  hero="crpg_captain_bot_320"
+                  troop="crpg_captain_bot_320"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_321"
+                  hero="crpg_captain_bot_321"
+                  troop="crpg_captain_bot_321"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_322"
+                  hero="crpg_captain_bot_322"
+                  troop="crpg_captain_bot_322"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_323"
+                  hero="crpg_captain_bot_323"
+                  troop="crpg_captain_bot_323"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_324"
+                  hero="crpg_captain_bot_324"
+                  troop="crpg_captain_bot_324"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_325"
+                  hero="crpg_captain_bot_325"
+                  troop="crpg_captain_bot_325"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_326"
+                  hero="crpg_captain_bot_326"
+                  troop="crpg_captain_bot_326"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_327"
+                  hero="crpg_captain_bot_327"
+                  troop="crpg_captain_bot_327"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_328"
+                  hero="crpg_captain_bot_328"
+                  troop="crpg_captain_bot_328"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_329"
+                  hero="crpg_captain_bot_329"
+                  troop="crpg_captain_bot_329"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_330"
+                  hero="crpg_captain_bot_330"
+                  troop="crpg_captain_bot_330"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_331"
+                  hero="crpg_captain_bot_331"
+                  troop="crpg_captain_bot_331"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_332"
+                  hero="crpg_captain_bot_332"
+                  troop="crpg_captain_bot_332"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_333"
+                  hero="crpg_captain_bot_333"
+                  troop="crpg_captain_bot_333"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_334"
+                  hero="crpg_captain_bot_334"
+                  troop="crpg_captain_bot_334"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_335"
+                  hero="crpg_captain_bot_335"
+                  troop="crpg_captain_bot_335"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_336"
+                  hero="crpg_captain_bot_336"
+                  troop="crpg_captain_bot_336"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_337"
+                  hero="crpg_captain_bot_337"
+                  troop="crpg_captain_bot_337"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_338"
+                  hero="crpg_captain_bot_338"
+                  troop="crpg_captain_bot_338"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_339"
+                  hero="crpg_captain_bot_339"
+                  troop="crpg_captain_bot_339"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_340"
+                  hero="crpg_captain_bot_340"
+                  troop="crpg_captain_bot_340"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_341"
+                  hero="crpg_captain_bot_341"
+                  troop="crpg_captain_bot_341"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_342"
+                  hero="crpg_captain_bot_342"
+                  troop="crpg_captain_bot_342"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_343"
+                  hero="crpg_captain_bot_343"
+                  troop="crpg_captain_bot_343"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_344"
+                  hero="crpg_captain_bot_344"
+                  troop="crpg_captain_bot_344"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_345"
+                  hero="crpg_captain_bot_345"
+                  troop="crpg_captain_bot_345"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_346"
+                  hero="crpg_captain_bot_346"
+                  troop="crpg_captain_bot_346"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_347"
+                  hero="crpg_captain_bot_347"
+                  troop="crpg_captain_bot_347"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_348"
+                  hero="crpg_captain_bot_348"
+                  troop="crpg_captain_bot_348"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_349"
+                  hero="crpg_captain_bot_349"
+                  troop="crpg_captain_bot_349"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_350"
+                  hero="crpg_captain_bot_350"
+                  troop="crpg_captain_bot_350"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_351"
+                  hero="crpg_captain_bot_351"
+                  troop="crpg_captain_bot_351"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_352"
+                  hero="crpg_captain_bot_352"
+                  troop="crpg_captain_bot_352"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_353"
+                  hero="crpg_captain_bot_353"
+                  troop="crpg_captain_bot_353"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_354"
+                  hero="crpg_captain_bot_354"
+                  troop="crpg_captain_bot_354"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_355"
+                  hero="crpg_captain_bot_355"
+                  troop="crpg_captain_bot_355"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_356"
+                  hero="crpg_captain_bot_356"
+                  troop="crpg_captain_bot_356"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_357"
+                  hero="crpg_captain_bot_357"
+                  troop="crpg_captain_bot_357"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_358"
+                  hero="crpg_captain_bot_358"
+                  troop="crpg_captain_bot_358"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_359"
+                  hero="crpg_captain_bot_359"
+                  troop="crpg_captain_bot_359"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_360"
+                  hero="crpg_captain_bot_360"
+                  troop="crpg_captain_bot_360"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_361"
+                  hero="crpg_captain_bot_361"
+                  troop="crpg_captain_bot_361"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_362"
+                  hero="crpg_captain_bot_362"
+                  troop="crpg_captain_bot_362"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_363"
+                  hero="crpg_captain_bot_363"
+                  troop="crpg_captain_bot_363"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_364"
+                  hero="crpg_captain_bot_364"
+                  troop="crpg_captain_bot_364"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_365"
+                  hero="crpg_captain_bot_365"
+                  troop="crpg_captain_bot_365"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_366"
+                  hero="crpg_captain_bot_366"
+                  troop="crpg_captain_bot_366"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_367"
+                  hero="crpg_captain_bot_367"
+                  troop="crpg_captain_bot_367"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_368"
+                  hero="crpg_captain_bot_368"
+                  troop="crpg_captain_bot_368"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_369"
+                  hero="crpg_captain_bot_369"
+                  troop="crpg_captain_bot_369"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_370"
+                  hero="crpg_captain_bot_370"
+                  troop="crpg_captain_bot_370"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_371"
+                  hero="crpg_captain_bot_371"
+                  troop="crpg_captain_bot_371"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_372"
+                  hero="crpg_captain_bot_372"
+                  troop="crpg_captain_bot_372"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_373"
+                  hero="crpg_captain_bot_373"
+                  troop="crpg_captain_bot_373"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_374"
+                  hero="crpg_captain_bot_374"
+                  troop="crpg_captain_bot_374"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_375"
+                  hero="crpg_captain_bot_375"
+                  troop="crpg_captain_bot_375"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_376"
+                  hero="crpg_captain_bot_376"
+                  troop="crpg_captain_bot_376"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_377"
+                  hero="crpg_captain_bot_377"
+                  troop="crpg_captain_bot_377"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_378"
+                  hero="crpg_captain_bot_378"
+                  troop="crpg_captain_bot_378"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_379"
+                  hero="crpg_captain_bot_379"
+                  troop="crpg_captain_bot_379"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_380"
+                  hero="crpg_captain_bot_380"
+                  troop="crpg_captain_bot_380"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_381"
+                  hero="crpg_captain_bot_381"
+                  troop="crpg_captain_bot_381"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_382"
+                  hero="crpg_captain_bot_382"
+                  troop="crpg_captain_bot_382"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_383"
+                  hero="crpg_captain_bot_383"
+                  troop="crpg_captain_bot_383"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_384"
+                  hero="crpg_captain_bot_384"
+                  troop="crpg_captain_bot_384"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_385"
+                  hero="crpg_captain_bot_385"
+                  troop="crpg_captain_bot_385"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_386"
+                  hero="crpg_captain_bot_386"
+                  troop="crpg_captain_bot_386"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_387"
+                  hero="crpg_captain_bot_387"
+                  troop="crpg_captain_bot_387"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_388"
+                  hero="crpg_captain_bot_388"
+                  troop="crpg_captain_bot_388"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_389"
+                  hero="crpg_captain_bot_389"
+                  troop="crpg_captain_bot_389"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_390"
+                  hero="crpg_captain_bot_390"
+                  troop="crpg_captain_bot_390"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_391"
+                  hero="crpg_captain_bot_391"
+                  troop="crpg_captain_bot_391"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_392"
+                  hero="crpg_captain_bot_392"
+                  troop="crpg_captain_bot_392"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_393"
+                  hero="crpg_captain_bot_393"
+                  troop="crpg_captain_bot_393"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_394"
+                  hero="crpg_captain_bot_394"
+                  troop="crpg_captain_bot_394"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_395"
+                  hero="crpg_captain_bot_395"
+                  troop="crpg_captain_bot_395"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_396"
+                  hero="crpg_captain_bot_396"
+                  troop="crpg_captain_bot_396"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_397"
+                  hero="crpg_captain_bot_397"
+                  troop="crpg_captain_bot_397"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_398"
+                  hero="crpg_captain_bot_398"
+                  troop="crpg_captain_bot_398"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_399"
+                  hero="crpg_captain_bot_399"
+                  troop="crpg_captain_bot_399"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
+</MPClassDivision>
+<MPClassDivision id="crpg_captain_bot_division_400"
+                  hero="crpg_captain_bot_400"
+                  troop="crpg_captain_bot_400"
+                  hero_idle_anim="act_vlandia_mp_sergeant_idle"
+                  troop_idle_anim="act_idle_1h_with_shield_1_left_stance"
+                  multiplier="0"
+                  cost="0"
+                  icon="infantry_light"
+                  melee_ai="50"
+                  ranged_ai="50"
+                  armor="0"
+                  movement_speed="0"
+                  combat_movement_speed="0"
+                  acceleration="0">
+  <Perks>
+    <Perk game_mode="all"
+          name="{=}None"
+          description="{=}None."
+          icon="PerkToughness"
+          perk_list="1">
+    </Perk>
+  </Perks>
 </MPClassDivision>
 </MPClassDivisions>


### PR DESCRIPTION
Agents were loading wrong stats from `CrpgAgentStatCalculateModel` in gamemodes where agents were not spawned during the same call of `SpawnAgents()`. This is because characters are now assigned a 'p' value, to identify different players when populating bot stats. However, in gamemodes where the spawning is more than once in a gamemode, the 'p' value of each agent would likely be set to 1.

`CrpgAgentStatCalculateModel` used this p value to set agent stats, causing the bug for these gamemodes.

I have refactored the code to use a separate set of character xml's for captain bots.
