### PR TITLE
mod: update lowpop logic

### DIFF
--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -249,8 +249,13 @@ internal class CrpgRewardServer : MissionLogic
             return;
         }
 
-        bool veryLowPopulationServer = networkPeers.Length < 2;
-        bool lowPopulationServer = !_isLowPopulationUpkeepEnabled && networkPeers.Length < 12;
+        var playingPeers = networkPeers
+            .Select(p => p.GetComponent<MissionPeer>())
+            .Where(mp => mp != null && mp.Team != Mission.SpectatorTeam)
+            .ToList();
+
+        bool veryLowPopulationServer = playingPeers.Count < 2;
+        bool lowPopulationServer = !_isLowPopulationUpkeepEnabled && playingPeers.Count < 12;
         // Force constant multiplier if there is low population.
         constantMultiplier = veryLowPopulationServer ? ExperienceMultiplierMin : constantMultiplier;
 


### PR DESCRIPTION
Calculates low population based on players who have a team, instead of including spectators.