### PR TITLE
webapi: add refund command

### DIFF
--- a/src/Application/Items/Commands/RefundItemCommand.cs
+++ b/src/Application/Items/Commands/RefundItemCommand.cs
@@ -1,0 +1,61 @@
+﻿using Crpg.Application.Common;
+using Crpg.Application.Common.Interfaces;
+using Crpg.Application.Common.Mediator;
+using Crpg.Application.Common.Results;
+using Crpg.Application.Items.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using LoggerFactory = Crpg.Logging.LoggerFactory;
+
+namespace Crpg.Application.Items.Commands;
+
+public record RefundItemCommand : IMediatorRequest
+{
+    public string ItemId { get; init; } = string.Empty;
+    public int UserId { get; init; }
+
+    internal class Handler : IMediatorRequestHandler<RefundItemCommand>
+    {
+        private static readonly ILogger Logger = LoggerFactory.CreateLogger<RefundItemCommand>();
+
+        private readonly ICrpgDbContext _db;
+
+        public Handler(ICrpgDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<Result> Handle(RefundItemCommand req, CancellationToken cancellationToken)
+        {
+            var item = await _db.Items
+                .FirstOrDefaultAsync(i => i.Id == req.ItemId, cancellationToken);
+            if (item == null)
+            {
+                return new(CommonErrors.ItemNotFound(req.ItemId));
+            }
+
+            var userItems = await _db.UserItems
+                .Include(ui => ui.User)
+                .Include(ui => ui.Item)
+                .Where(ui => ui.ItemId == item.Id)
+                .ToArrayAsync(cancellationToken);
+            foreach (var userItem in userItems)
+            {
+                userItem.User!.Gold += userItem.Item!.Price;
+                // Trick to avoid UpdatedAt to be updated.
+                userItem.User.UpdatedAt = userItem.User.UpdatedAt;
+                if (userItem.Item!.Rank > 0)
+                {
+                    userItem.User.HeirloomPoints += userItem.Item!.Rank;
+                }
+
+                _db.UserItems.Remove(userItem);
+            }
+
+            await _db.SaveChangesAsync(cancellationToken);
+
+            Logger.LogInformation("User '{0}' refunded item '{2}'", req.UserId, req.ItemId);
+            return Result.NoErrors;
+        }
+    }
+}

--- a/src/WebApi/Controllers/ItemsController.cs
+++ b/src/WebApi/Controllers/ItemsController.cs
@@ -51,4 +51,19 @@ public class ItemsController : BaseController
         req = req with { ItemId = id, UserId = CurrentUser.User!.Id };
         return ResultToActionAsync(Mediator.Send(req));
     }
+
+    /// <summary>
+    /// Refund item.
+    /// </summary>
+    /// <param name="id">Item id.</param>
+    /// <param name="req">Value.</param>
+    /// <response code="200">OK.</response>
+    /// <response code="400">Bad Request.</response>
+    [Authorize(Policy = AdminPolicy)]
+    [HttpPost("{id}/refund")]
+    public Task<ActionResult> RefundItem([FromRoute] string id, [FromBody] RefundItemCommand req)
+    {
+        req = req with { ItemId = id, UserId = CurrentUser.User!.Id };
+        return ResultToActionAsync(Mediator.Send(req));
+    }
 }

--- a/test/Application.UTest/Items/RefundItemCommandTest.cs
+++ b/test/Application.UTest/Items/RefundItemCommandTest.cs
@@ -1,0 +1,50 @@
+using Crpg.Application.Common.Results;
+using Crpg.Application.Items.Commands;
+using Crpg.Domain.Entities.Characters;
+using Crpg.Domain.Entities.Items;
+using Crpg.Domain.Entities.Users;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace Crpg.Application.UTest.Items;
+
+public class RefundItemCommandTest : TestBase
+{
+    [Test]
+    public async Task ShouldReturnErrorIfItemIsNotFound()
+    {
+        User user = new();
+        ArrangeDb.Users.Add(user);
+        await ArrangeDb.SaveChangesAsync();
+
+        var result = await new RefundItemCommand.Handler(ActDb).Handle(new RefundItemCommand
+        {
+            ItemId = "a",
+            UserId = user.Id,
+        }, CancellationToken.None);
+        Assert.That(result.Errors![0].Code, Is.EqualTo(ErrorCode.ItemNotFound));
+    }
+
+    [Test]
+    public async Task ShouldRefundItem()
+    {
+        Item item = new() { Id = "a", Enabled = true, Price = 100, Rank = 1 };
+        ArrangeDb.Items.Add(item);
+        User user = new();
+        ArrangeDb.Users.Add(user);
+        UserItem userItem = new() { User = user, ItemId = item.Id };
+        ArrangeDb.UserItems.Add(userItem);
+        await ArrangeDb.SaveChangesAsync();
+
+        var result = await new RefundItemCommand.Handler(ActDb).Handle(new RefundItemCommand
+        {
+            ItemId = item.Id,
+            UserId = user.Id,
+        }, CancellationToken.None);
+
+        Assert.That(result.Errors, Is.Null);
+        user = AssertDb.Users.First(u => u.Id == user.Id);
+        Assert.That(user.Gold, Is.EqualTo(100));
+        Assert.That(user.HeirloomPoints, Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
adds a refund itemid api endpoint

with the implementation of #349 we can now create items that are disabled in the api by default (such as holiday items). we can now activate and deactive them without editing the items.json file, but if they are purchased or loomed, we need a way to refund them.