### PR TITLE
webapi: trim donor details

### DIFF
--- a/src/WebApi/Workers/DonorSynchronizerWorker.cs
+++ b/src/WebApi/Workers/DonorSynchronizerWorker.cs
@@ -72,10 +72,10 @@ internal class DonorSynchronizerWorker : BackgroundService
                 continue;
             }
 
-            string[] noteLines = member.Attributes.Note.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            string[] noteLines = member.Attributes.Note.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             foreach (string noteLine in noteLines)
             {
-                string[] noteParts = noteLine.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                string[] noteParts = noteLine.Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 if (noteParts.Length == 2 && noteParts[0] == "steam")
                 {
                     steamIds.Add(noteParts[1]);


### PR DESCRIPTION
uses `StringSplitOptions.TrimEntries` to Trim white-space characters from each substring in the result. 

If [RemoveEmptyEntries](https://learn.microsoft.com/en-us/dotnet/api/system.stringsplitoptions?view=net-9.0#system-stringsplitoptions-removeemptyentries) and [TrimEntries](https://learn.microsoft.com/en-us/dotnet/api/system.stringsplitoptions?view=net-9.0#system-stringsplitoptions-trimentries) are specified together, then substrings that consist only of white-space characters are also removed from the result.

https://learn.microsoft.com/en-us/dotnet/api/system.stringsplitoptions?view=net-9.0