### PR TITLE
mod: Randomise map rotation

### DIFF
--- a/src/Module.Server/CrpgSubModule.cs
+++ b/src/Module.Server/CrpgSubModule.cs
@@ -128,51 +128,58 @@ internal class CrpgSubModule : MBSubModuleBase
 
         string currentConfigFilePath = TaleWorlds.MountAndBlade.Module.CurrentModule.StartupInfo.CustomGameServerConfigFile;
         string mapconfigfilepath = Path.Combine(Directory.GetCurrentDirectory(), ModuleHelper.GetModuleFullPath("cRPG"), currentConfigFilePath.Replace(".txt", string.Empty) + "_maps.txt");
+
         if (File.Exists(mapconfigfilepath))
         {
             try
             {
                 string[] maps = File.ReadAllLines(mapconfigfilepath);
 
-                int startIndex = Random.Next(maps.Length); // Random start index between 0 and maps.Length - 1
-                for (int i = 0; i < maps.Length; i++)
+                // Remove empty or invalid map entries
+                maps = maps.Where(map => !string.IsNullOrWhiteSpace(map)).ToArray();
+
+                // Shuffle maps using Fisher-Yates Shuffle
+                Debug.Print("Shuffling maps for random order.", color: Debug.DebugColor.Cyan);
+                for (int i = maps.Length - 1; i > 0; i--)
                 {
-                    int currentIndex = (startIndex + i) % maps.Length;
-                    string map = maps[currentIndex];
+                    int j = Random.Next(i + 1);
+                    (maps[i], maps[j]) = (maps[j], maps[i]);
+                }
 
-                    if (map == string.Empty)
-                    {
-                        continue;
-                    }
+                // Debug: Print shuffled map list
+                Debug.Print("Shuffled map order:", color: Debug.DebugColor.Green);
+                foreach (string map in maps)
+                {
+                    Debug.Print($"- {map}", color: Debug.DebugColor.Green);
+                }
 
+                // Add each map to the server's usable maps and automated battle pool
+                foreach (string map in maps)
+                {
                     if (ServerSideIntermissionManager.Instance != null)
                     {
                         ServerSideIntermissionManager.Instance.AddMapToUsableMaps(map);
                         ServerSideIntermissionManager.Instance.AddMapToAutomatedBattlePool(map);
-                        Debug.Print($"added {map} to map pool", color: Debug.DebugColor.Red);
+                        Debug.Print($"Added {map} to usable maps and automated battle pool.", color: Debug.DebugColor.Red);
                     }
                     else
                     {
-                        for (int j = 0; j < 10; j++)
-                        {
-                            Debug.Print($"There's no instance of ServerSideIntermissionManager", color: Debug.DebugColor.Red);
-                        }
+                        Debug.Print("ServerSideIntermissionManager instance is null. Unable to add maps.", color: Debug.DebugColor.Red);
                     }
                 }
             }
             catch (Exception e)
             {
-                Debug.Print($"could not read the map file {mapconfigfilepath}", color: Debug.DebugColor.Red);
-                Debug.Print($"{e.Message}", color: Debug.DebugColor.Red);
+                Debug.Print($"Error reading the map file {mapconfigfilepath}: {e.Message}", color: Debug.DebugColor.Red);
             }
         }
         else
         {
-            Debug.Print("No separate map file");
+            Debug.Print($"Map configuration file not found: {mapconfigfilepath}", color: Debug.DebugColor.Red);
         }
 
         _mapPoolAdded = true;
-        return;
+        Debug.Print("Finished adding maps to the rotation.", color: Debug.DebugColor.Cyan);
     }
 
 #endif

--- a/src/Module.Server/MapRotation/ds_config_crpg_battle.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_battle.txt
@@ -1,5 +1,5 @@
-ServerName Livetest c-rpg.eu works now 800
-GameType cRPGCaptain
+ServerName Test Battle
+GameType cRPGBattle
 WelcomeMessage yoyoyooooo
 AllowPollsToKickPlayers True
 AllowPollsToChangeMaps True
@@ -20,11 +20,12 @@ NumberOfBotsTeam2 0
 NumberOfBotsPerFormation 10
 RoundTotal 10
 MapTimeLimit 8
-RoundTimeLimit 600
-WarmupTimeLimit 1
+RoundTimeLimit 60
+WarmupTimeLimit 60
 crpg_happy_hours 19:00-23:00,Central European Standard Time
 start_game
 set_automated_battle_count -1
 enable_automated_battle_switching
 crpg_frozen_bots False
 crpg_apply_harmony_patches
+GamePassword yoyo

--- a/src/Module.Server/MapRotation/ds_config_crpg_battle_maps.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_battle_maps.txt
@@ -1,2 +1,9 @@
-crpg_battle_howlingmeadow
-crpg_battle_howlingmeadow
+crpg_battle_cabbagepatch
+crpg_battle_skyfall
+crpg_battle_westveen
+crpg_battle_zemouri
+crpg_battle_drakenburg
+crpg_battle_vatnborg
+crpg_battle_lighthouse
+crpg_battle_hexenbrennen
+crpg_battle_monastery


### PR DESCRIPTION
Randomize map rotation using the Fisher-Yates shuffle.

This change implements the Fisher-Yates shuffle algorithm to randomize the order of maps in the map rotation. Previously rotation was random on the initial map pick but after that followed the rotation downwards leading to a repetitive experience at times (as you eventually would always know what map comes next)

This change shuffles the map order each time the server is started, which works alongside processes already in place as the servers currently reboot nightly regardless, **_however is also a potential consideration to factor into this review as it could lead to (albeit minor) issues if we ever disposed of the nightly reboots._**