### PR TITLE
fix: fadeout agents on round end to prevent them from dying

### DIFF
--- a/src/Module.Server/Common/TeamSelect/CrpgTeamSelectServerComponent.cs
+++ b/src/Module.Server/Common/TeamSelect/CrpgTeamSelectServerComponent.cs
@@ -161,6 +161,15 @@ internal class CrpgTeamSelectServerComponent : MultiplayerTeamSelectComponent
 
         Dictionary<int, Team> usersToMove = ResolveTeamMoves(current: gameMath, target: balancedGameMatch);
 
+        var agentsToFadeOut = Mission.Current.Agents.ToList();
+        foreach (Agent agent in agentsToFadeOut)
+        {
+            if (agent != null && !agent.IsMount && agent.IsActive())
+            {
+                agent.FadeOut(true, true);
+            }
+        }
+
         var crpgNetworkPeers = GetCrpgNetworkPeers();
         SendSwapNotification(usersToMove, crpgNetworkPeers);
 


### PR DESCRIPTION
Error was caused when `fadeout` was called on a mount which had a rider. Refactored to only call `fadeout` on humans, and keep bool to hidemount, as it checks for a `MountAgent` anyway.