### PR TITLE
Changed maximum STR req for heavy and light xbows

### DIFF
--- a/src/Module.Server/Common/Models/CrpgItemRequirementModel.cs
+++ b/src/Module.Server/Common/Models/CrpgItemRequirementModel.cs
@@ -23,13 +23,26 @@ internal class CrpgItemRequirementModel
     }
 
     private static int ComputeCrossbowRequirement(ItemObject item)
-    {
-        int strengthRequirementForTierTenCrossbow = 24; // Tiers are calulated in CrpgValueModel. 0<Tier=<10 . By design the best is always at Ten.
-        if (item.ItemType != ItemObject.ItemTypeEnum.Crossbow)
-        {
-            throw new ArgumentException(item.Name.ToString() + " is not a crossbow");
-        }
+{
+    int strengthRequirementForTierTenCrossbow;
 
-        return ((int)(item.Tierf * (strengthRequirementForTierTenCrossbow / 9.9f)) / 3) * 3;
+    // Check if the item is a crossbow
+    if (item.ItemType != ItemObject.ItemTypeEnum.Crossbow)
+    {
+        throw new ArgumentException(item.Name.ToString() + " is not a crossbow");
     }
+
+    // Adjust the strength requirement for light crossbows
+    if (item.ItemUsage == "crossbow_light")
+    {
+        strengthRequirementForTierTenCrossbow = 18; // For light crossbows
+    }
+    else
+    {
+        strengthRequirementForTierTenCrossbow = 20; // Default for other crossbows
+    }
+
+    // Compute the strength requirement based on tier
+    return (int)(Math.Ceiling((item.Tierf * (strengthRequirementForTierTenCrossbow / 9.9f)) / 3) * 3);
+}
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/82da863e-d8e7-4421-867f-9be7da343bda)

Changed the STR req for xbows depending if they are heavy or light. Changes seen above.

Goals:
- Reduce 24 STR req xbows to 21
- Reduce Templar Light Xbow to 15
- Creates code area for easy tweaking of light and heavy in the future

Significant changes:
- Final STR req is rounded up to the nearest 3, instead of down. This is why xbows have >20STR req despite that being the "maximum"
- Checks for itemusage == crossbow.light to achieve the differentitation

Considerations
- One of the horse loading xbows has dropped from 15STR to 12STR. I don't think that's a problem personally. Can always change the 1.85f increase in horseloading xbows to push this up more
- I have no idea how to link this into ItemBalance repo etc etc
