### PR TITLE
mod: improve respawn timer

### DIFF
--- a/src/Module.Server/Common/CrpgRespawnTimerServer.cs
+++ b/src/Module.Server/Common/CrpgRespawnTimerServer.cs
@@ -13,13 +13,52 @@ internal class CrpgRespawnTimerServer : MissionNetwork
         _spawnBehavior = spawnBehavior;
     }
 
+    public override void OnBehaviorInitialize()
+    {
+        base.OnBehaviorInitialize();
+        MissionPeer.OnTeamChanged += HandlePeerTeamChanged;
+    }
+
+    public override void OnRemoveBehavior()
+    {
+        base.OnRemoveBehavior();
+        MissionPeer.OnTeamChanged -= HandlePeerTeamChanged;
+    }
+
+    public override void OnAgentBuild(Agent agent, Banner banner)
+    {
+        NetworkCommunicator? networkCommunicator = agent.MissionPeer?.GetNetworkPeer();
+        if (networkCommunicator != null && !_missionMultiplayerGameModeBase.WarmupComponent.IsInWarmup)
+        {
+            GameNetwork.BeginModuleEventAsServer(networkCommunicator);
+            GameNetwork.WriteMessage(new CrpgUpdateRespawnTimerMessage { TimeToSpawn = 0 });
+            GameNetwork.EndModuleEventAsServer();
+        }
+    }
+
     public override void OnAgentRemoved(Agent affectedAgent, Agent affectorAgent, AgentState agentState, KillingBlow blow)
     {
+        if (blow.OverrideKillInfo == Agent.KillInfo.TeamSwitch)
+        {
+            return;
+        }
+
         NetworkCommunicator? networkCommunicator = affectedAgent.MissionPeer?.GetNetworkPeer();
         if (networkCommunicator != null && !_missionMultiplayerGameModeBase.WarmupComponent.IsInWarmup)
         {
             float timeUntilRespawn = _spawnBehavior.TimeUntilRespawn(affectedAgent.Team);
             GameNetwork.BeginModuleEventAsServer(networkCommunicator);
+            GameNetwork.WriteMessage(new CrpgUpdateRespawnTimerMessage { TimeToSpawn = timeUntilRespawn });
+            GameNetwork.EndModuleEventAsServer();
+        }
+    }
+
+    private void HandlePeerTeamChanged(NetworkCommunicator peer, Team previousTeam, Team newTeam)
+    {
+        if (peer != null && !_missionMultiplayerGameModeBase.WarmupComponent.IsInWarmup)
+        {
+            float timeUntilRespawn = _spawnBehavior.TimeUntilRespawn(newTeam);
+            GameNetwork.BeginModuleEventAsServer(peer);
             GameNetwork.WriteMessage(new CrpgUpdateRespawnTimerMessage { TimeToSpawn = timeUntilRespawn });
             GameNetwork.EndModuleEventAsServer();
         }

--- a/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
@@ -9,6 +9,7 @@ using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.MissionRepresentatives;
 using TaleWorlds.MountAndBlade.Objects;
 using TaleWorlds.ObjectSystem;
+using Crpg.Module.Modes.Siege;
 
 namespace Crpg.Module.Modes.Conquest;
 
@@ -319,6 +320,11 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
 
         _rewardTickTimer = new MissionTimer(duration: CrpgServerConfiguration.RewardTick);
         _wasCurrentStageNotifiedAboutOvertime = false;
+
+        if (SpawnComponent.SpawningBehavior is CrpgSiegeSpawningBehavior s)
+        {
+            s.SetSpawnOverride(0.5f);
+        }
     }
 
     private void TickFlags()

--- a/src/Module.Server/Modes/Siege/CrpgSiegeSpawningBehavior.cs
+++ b/src/Module.Server/Modes/Siege/CrpgSiegeSpawningBehavior.cs
@@ -7,6 +7,9 @@ namespace Crpg.Module.Modes.Siege;
 
 internal class CrpgSiegeSpawningBehavior : CrpgSpawningBehaviorBase
 {
+    private bool _allowSpawnTimerOverride = false;
+    private MissionTimer? _spawnTimerOverrideTimer;
+
     public CrpgSiegeSpawningBehavior(CrpgConstants constants)
         : base(constants)
     {
@@ -23,6 +26,16 @@ internal class CrpgSiegeSpawningBehavior : CrpgSpawningBehaviorBase
         SpawnAgents();
         SpawnBotAgents();
         TimeSinceSpawnEnabled += dt;
+        if (_spawnTimerOverrideTimer != null && _spawnTimerOverrideTimer.Check())
+        {
+            _allowSpawnTimerOverride = false;
+        }
+    }
+
+    public void SetSpawnOverride(float timerDuration)
+    {
+        _allowSpawnTimerOverride = true;
+        _spawnTimerOverrideTimer = new MissionTimer(timerDuration);
     }
 
     protected override bool IsRoundInProgress()
@@ -43,7 +56,7 @@ internal class CrpgSiegeSpawningBehavior : CrpgSpawningBehaviorBase
         int respawnPeriod = missionPeer.Team.Side == BattleSideEnum.Defender
             ? MultiplayerOptions.OptionType.RespawnPeriodTeam2.GetIntValue()
             : MultiplayerOptions.OptionType.RespawnPeriodTeam1.GetIntValue();
-        if (TimeSinceSpawnEnabled != 0 && TimeSinceSpawnEnabled % respawnPeriod > 1)
+        if (TimeSinceSpawnEnabled != 0 && !_allowSpawnTimerOverride && TimeSinceSpawnEnabled % respawnPeriod > 1)
         {
             return false;
         }


### PR DESCRIPTION
Added 0.5f spawn timer override for both teams on the start of a new stage in conquest
Respawn timer correctly displays remaining time if you change team
Respawn timer disappears if you spawn earlier than the timer