### PR TITLE
Crossbow STR reqs adjustment

### DIFF
--- a/src/Module.Server/Common/Models/CrpgItemRequirementModel.cs
+++ b/src/Module.Server/Common/Models/CrpgItemRequirementModel.cs
@@ -24,12 +24,25 @@ internal class CrpgItemRequirementModel
 
     private static int ComputeCrossbowRequirement(ItemObject item)
     {
-        int strengthRequirementForTierTenCrossbow = 24; // Tiers are calulated in CrpgValueModel. 0<Tier=<10 . By design the best is always at Ten.
+        int strengthRequirementForTierTenCrossbow;
+
+        // Check if the item is a crossbow
         if (item.ItemType != ItemObject.ItemTypeEnum.Crossbow)
         {
             throw new ArgumentException(item.Name.ToString() + " is not a crossbow");
         }
 
-        return ((int)(item.Tierf * (strengthRequirementForTierTenCrossbow / 9.9f)) / 3) * 3;
+        // Adjust the strength requirement for light crossbows
+        if (item.WeaponComponent.PrimaryWeapon.ItemUsage.Contains("crossbow_light"))
+        {
+            strengthRequirementForTierTenCrossbow = 18; // For light crossbows
+        }
+        else
+        {
+            strengthRequirementForTierTenCrossbow = 20; // Default for other crossbows
+        }
+
+        // Compute the strength requirement based on tier
+        return (int)(Math.Ceiling((item.Tierf * (strengthRequirementForTierTenCrossbow / 9.9f)) / 3) * 3);
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/26189fc9-dd1f-4ef8-b3b5-198743707917)

Goals:

Reduce 24 STR req xbows to 21
Reduce Templar Light Xbow to 15
Creates code area for easy tweaking of light and heavy in the future
Significant changes:

Final STR req is rounded up to the nearest 3, instead of down. This is why xbows have >20STR req despite that being the "maximum"
Checks for itemusage == crossbow.light to achieve the differentitation
Considerations

One of the horse loading xbows has dropped from 15STR to 12STR. I don't think that's a problem personally. Can always change the 1.85f increase in horseloading xbows to push this up more