### PR TITLE
mod: rework inactivity handling

### DIFF
--- a/src/Module.Client/Module.Client.csproj
+++ b/src/Module.Client/Module.Client.csproj
@@ -30,6 +30,7 @@
     <Compile Remove="..\Module.Server\Rating\**" />
     <Compile Remove="..\Module.Server\Api\*Client.cs" />
     <Compile Remove="..\Module.Server\Common\Commander\CommanderBehaviorServer.cs" />
+    <Compile Remove="..\Module.Server\Common\KickInactiveBehavior.cs" />
     <Compile Remove="..\Module.Server\Modes\Battle\CrpgBattleServer.cs" />
     <Compile Remove="..\Module.Server\Modes\Conquest\CrpgConquestServer.cs" />
     <Compile Remove="..\Module.Server\Modes\Duel\CrpgDuelServer.cs" />

--- a/src/Module.Editor/Module.Editor.csproj
+++ b/src/Module.Editor/Module.Editor.csproj
@@ -34,6 +34,7 @@
     <Compile Remove="GUI\**" />
     <Compile Remove="obj\**" />
     <Compile Remove="..\Module.Server\Common\Commander\CommanderBehaviorServer.cs" />
+    <Compile Remove="..\Module.Server\Common\KickInactiveBehavior.cs" />
     <Compile Remove="..\Module.Server\Modes\Battle\CrpgBattleServer.cs" />
     <Compile Remove="..\Module.Server\Modes\Conquest\CrpgConquestServer.cs" />
     <Compile Remove="..\Module.Server\Modes\Duel\CrpgDuelServer.cs" />

--- a/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
@@ -187,7 +187,7 @@ internal class CrpgBattleGameMode : MissionBasedMultiplayerGameMode
                     new AgentHumanAILogic(), // bot intelligence
                     new MultiplayerAdminComponent(), // admin UI to kick player or restart game
                     new CrpgUserManagerServer(crpgClient, _constants),
-                    new KickInactiveBehavior(inactiveTimeLimit: 60, warmupComponent),
+                    new KickInactiveBehavior(inactiveTimeLimit: 30, warmupComponent, teamSelectComponent),
                     new MapPoolComponent(),
                     new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),
                     new ServerMetricsBehavior(),

--- a/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
@@ -139,7 +139,7 @@ internal class CrpgConquestGameMode : MissionBasedMultiplayerGameMode
                 rewardServer,
                 new SpawnComponent(new SiegeSpawnFrameBehavior(), spawnBehavior),
                 new CrpgUserManagerServer(crpgClient, _constants),
-                new KickInactiveBehavior(inactiveTimeLimit: 90, warmupComponent),
+                new KickInactiveBehavior(inactiveTimeLimit: 90, warmupComponent, teamSelectComponent),
                 new MapPoolComponent(),
                 new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),
                 new ServerMetricsBehavior(),

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
@@ -143,7 +143,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
                 new AgentHumanAILogic(),
                 new MultiplayerAdminComponent(),
                 new CrpgUserManagerServer(crpgClient, _constants),
-                new KickInactiveBehavior(inactiveTimeLimit: 60, warmupComponent),
+                new KickInactiveBehavior(inactiveTimeLimit: 60, warmupComponent, teamSelectComponent),
                 new MapPoolComponent(),
                 new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),
                 new ServerMetricsBehavior(),

--- a/src/Module.Server/ModuleData/multiplayer_strings.xml
+++ b/src/Module.Server/ModuleData/multiplayer_strings.xml
@@ -66,7 +66,8 @@
   <string id="str_notification.cavalry_spawn_delay" text="{=v1S1BAF4}Cavalry will spawn in {SECONDS} seconds!" />
   <string id="str_notification.conquest_overtime" text="{=joWaOGco}The time limit was reached but some attackers are still around the flags. Defenders will need to wipe them to win the game." />
   <string id="str_notification.entities_removed" text="{=I5MWE5AR}{ENTITY_COUNT} entities were removed from the map given the population size." />
-
+  <string id="str_notification.moved_to_spectator" text="{=iN5cT1v3}You have been moved to spectator due to inactivity!" />
+  
   <!-- Battle Maps -->
   <string id="str_multiplayer_scene_name.crpg_battle_abandoned" text="{=PKVPlAeE}Abandoned" />
   <string id="str_multiplayer_scene_name.crpg_battle_acaciacitadel" text="{=tZJ32ZRQ}Acacia Citadel" />


### PR DESCRIPTION
- Users are now moved to spectator instead of kicked if possible
- Warning sound now plays when a player is warned about inactivity
- Inactivity timer reduced to 30 seconds from 60 in battle
- Inactivity timer only checks during the first 65 seconds of each round in battle
- Admins are no longer kicked due to inactivity