### PR TITLE
Exporter blunt, BvS, 1h mace budget adjustment

### DIFF
--- a/src/Module.Server/Common/Models/CrpgItemValueModel.cs
+++ b/src/Module.Server/Common/Models/CrpgItemValueModel.cs
@@ -26,10 +26,10 @@ internal class CrpgItemValueModel : ItemValueModel
         [ItemObject.ItemTypeEnum.LegArmor] = (3090, ArmorPriceCoeffs),
         [ItemObject.ItemTypeEnum.HorseHarness] = (9000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Horse] = (9000, ItemPriceCoeffs),
-        [ItemObject.ItemTypeEnum.Shield] = (7000, ItemPriceCoeffs),
+        [ItemObject.ItemTypeEnum.Shield] = (5000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Bow] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Crossbow] = (14000, ItemPriceCoeffs),
-        [ItemObject.ItemTypeEnum.OneHandedWeapon] = (7000, ItemPriceCoeffs),
+        [ItemObject.ItemTypeEnum.OneHandedWeapon] = (9000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.TwoHandedWeapon] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Polearm] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Thrown] = (6000, ItemPriceCoeffs),
@@ -170,7 +170,7 @@ internal class CrpgItemValueModel : ItemValueModel
             {
                 WeaponClass.OneHandedSword => 20.9f,
                 WeaponClass.OneHandedAxe => 25.3f,
-                WeaponClass.Mace => 25.3f,
+                WeaponClass.Mace => 20.0f,
                 WeaponClass.Dagger => 20.9f,
                 WeaponClass.TwoHandedSword => 27.5f,
                 WeaponClass.TwoHandedMace => 28.5f,
@@ -218,6 +218,8 @@ internal class CrpgItemValueModel : ItemValueModel
                     case WeaponClass.Dagger:
                     case WeaponClass.OneHandedSword:
                     case WeaponClass.TwoHandedSword:
+                    case WeaponClass.TwoHandedPolearm:
+                    case WeaponClass.Mace:
                         swingTier *= 1.2f;
                         break;
                     default:
@@ -233,7 +235,7 @@ internal class CrpgItemValueModel : ItemValueModel
 
             if (weapon.WeaponFlags.HasAnyFlag(WeaponFlags.CanKnockDown))
             {
-                swingTier *= 1.6f;
+                swingTier *= 1.45f;
             }
 
             if (weapon.WeaponFlags.HasAnyFlag(WeaponFlags.MultiplePenetration))
@@ -261,8 +263,10 @@ internal class CrpgItemValueModel : ItemValueModel
                 case WeaponClass.OneHandedSword:
                 case WeaponClass.Dagger:
                 case WeaponClass.OneHandedAxe:
-                case WeaponClass.Mace:
                     swingLengthTier = 0.455f * (float)Math.Pow(0.8f + weapon.WeaponLength * 0.01f, 2f);
+                    break;
+                case WeaponClass.Mace:
+                    swingLengthTier = 0.49f * (float)Math.Pow(0.8f + weapon.WeaponLength * 0.01f, 2f);
                     break;
                 case WeaponClass.TwoHandedSword:
                 case WeaponClass.TwoHandedMace:
@@ -313,7 +317,7 @@ internal class CrpgItemValueModel : ItemValueModel
     {
         return damageType switch
         {
-            DamageTypes.Blunt => 3f,
+            DamageTypes.Blunt => 3.3f,
             DamageTypes.Pierce => 2.2f,
             _ => 1.0f,
         };


### PR DESCRIPTION
See https://github.com/namidaka/itembalancing/pull/528 for effects

1h maximum price increased to 9000 (+2000)
Shield maximum price decreased to 5000 (-2000)
Increased the cost of 1h mace swing stats
Decreased the cost of canknockdown
Increased the cost of length for 1h maces
Increased the cost of blunt for all weapon types
Increased the cost of BvS for two handed polearms and 1h maces

Intended effects:

Make powerful 1h more expensive to reflect their power level, whilst not increasing average cost for sword and board classes through shield price reduction, also encouragaing players to take shields more often in general. NOTE this does lower non-1h shield classes overall cost slightly, most notably hoplite/cavalry. If we don't like this can remove the price change altogether, or just increase 1h cost etc.

Blunt was too cost effectives, the breakeven point for average 1h cut vs 1h blunt was around 35 body armour. Now it is around 45. 

In general, 1h maces have lost 2 blunt damage, speed and handling. Non-1h maces with blunt damage have lost 1 damage.

BvS was too cheap on polearms, cost increase has lowered damage of BvS polearms by 2. BvS has been removed from blunt & pierce weapons, as it was a significant cost increase for very little gain compared to cut (will investigate BvS cost against damage type in future).

Exceptions apply for specific weapons.