### PR TITLE
mod: dtv bot aggro timer

### DIFF
--- a/src/Module.Server/Common/AiComponents/DtvAiComponent.cs
+++ b/src/Module.Server/Common/AiComponents/DtvAiComponent.cs
@@ -15,6 +15,11 @@ public class DtvAiComponent : CommonAIComponent
     {
     }
 
+    public override void Initialize() // Not being called automatically when the component is instantiated
+    {
+        _targetTimer = new(ViscountTargetTimerDuration * 2);
+    }
+
     public override void OnTickAsAI(float dt)
     {
         _tickOccasionally ??= new(1f);

--- a/src/Module.Server/Common/AiComponents/DtvAiComponent.cs
+++ b/src/Module.Server/Common/AiComponents/DtvAiComponent.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.Common.AiComponents;
+public class DtvAiComponent : CommonAIComponent
+{
+    private const int ViscountTargetTimerDuration = 30;
+    private MissionTimer? _targetTimer;
+    private MissionTimer? _tickOccasionally;
+    public DtvAiComponent(Agent agent)
+        : base(agent)
+    {
+    }
+
+    public override void OnTickAsAI(float dt)
+    {
+        _tickOccasionally ??= new(1f);
+        if (_tickOccasionally.Check(true))
+        {
+            TickOccasionally();
+        }
+    }
+
+    public override void OnHit(Agent affectorAgent, int damage, in MissionWeapon affectorWeapon)
+    {
+        if (damage > 0 && affectorAgent.Team == Mission.Current.Teams.Defender)
+        {
+            ResetTargetTimer();
+        }
+    }
+
+    public void ResetTargetTimer()
+    {
+        _targetTimer = null;
+        Agent.SetAutomaticTargetSelection(true);
+    }
+
+    private void TickOccasionally()
+    {
+        CheckTargetTimer();
+    }
+
+    private void CheckTargetTimer()
+    {
+        _targetTimer ??= new(ViscountTargetTimerDuration);
+        if (_targetTimer.Check(false))
+        {
+            FocusVip();
+        }
+    }
+
+    private void FocusVip()
+    {
+        var agents = Mission.Current.Agents.ToList();
+        foreach (Agent agent in agents)
+        {
+            if (agent.Origin.Troop.StringId.StartsWith("crpg_dtv_vip_"))
+            {
+                Agent.SetAutomaticTargetSelection(false);
+                Agent.SetTargetAgent(agent);
+                break;
+            }
+        }
+    }
+}

--- a/src/Module.Server/Common/AiComponents/DtvAiComponent.cs
+++ b/src/Module.Server/Common/AiComponents/DtvAiComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Crpg.Module.Helpers;
 using TaleWorlds.MountAndBlade;
 
 namespace Crpg.Module.Common.AiComponents;
@@ -25,7 +26,7 @@ public class DtvAiComponent : CommonAIComponent
 
     public override void OnHit(Agent affectorAgent, int damage, in MissionWeapon affectorWeapon)
     {
-        if (damage > 0 && affectorAgent.Team == Mission.Current.Teams.Defender)
+        if (affectorAgent.Team == Mission.Current.Teams.Defender)
         {
             ResetTargetTimer();
         }
@@ -44,7 +45,7 @@ public class DtvAiComponent : CommonAIComponent
 
     private void CheckTargetTimer()
     {
-        _targetTimer ??= new(ViscountTargetTimerDuration);
+        _targetTimer ??= new(MathHelper.RandomWithVariance(ViscountTargetTimerDuration, 0.2f));
         if (_targetTimer.Check(false))
         {
             FocusVip();

--- a/src/Module.Server/Helpers/MathHelper.cs
+++ b/src/Module.Server/Helpers/MathHelper.cs
@@ -65,4 +65,14 @@ internal static class MathHelper
             ? value >= bound1 && value <= bound2
             : value >= bound2 && value <= bound1;
     }
+
+    public static int RandomWithVariance(int value, double variancePercentage)
+    {
+        var random = new Random();
+        int variance = (int)(value * variancePercentage);
+        int min = value - variance;
+        int max = value + variance;
+
+        return random.Next(min, max + 1);
+    }
 }

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Serialization;
 using Crpg.Module.Common;
+using Crpg.Module.Common.AiComponents;
 using Crpg.Module.Rewards;
 using NetworkMessages.FromServer;
 using TaleWorlds.Core;
@@ -218,6 +219,12 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         if (affectedAgent.IsAIControlled && affectedAgent.Team == Mission.DefenderTeam) // VIP under attack
         {
             SendDataToPeers(new CrpgDtvVipUnderAttackMessage { AgentAttackerIndex = affectorAgent.Index, AgentVictimIndex = affectedAgent.Index });
+        }
+
+        if (affectorAgent.Team == Mission.AttackerTeam && affectorAgent.IsAIControlled && affectedAgent.Team == Mission.DefenderTeam)
+        {
+            DtvAiComponent component = affectorAgent.GetComponent<DtvAiComponent>();
+            component?.ResetTargetTimer();
         }
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using Crpg.Module.Common;
+using Crpg.Module.Common.AiComponents;
 using Crpg.Module.Common.Network;
 using Crpg.Module.Notifications;
 using TaleWorlds.Core;
@@ -20,6 +21,12 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
     {
         _notifiedPlayersAboutSpawnRestriction = new HashSet<PlayerId>();
         CurrentGameMode = MultiplayerGameType.FreeForAll;
+    }
+
+    public override void Initialize(SpawnComponent spawnComponent)
+    {
+        base.Initialize(spawnComponent);
+        Mission.Current.AllowAiTicking = true;
     }
 
     public override void OnTick(float dt)
@@ -125,7 +132,8 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
             Debug.Print($"Spawning {groupBotCount} {group.ClassDivisionId}(s)");
             for (int i = 0; i < groupBotCount; i++)
             {
-                SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
+                Agent agent = SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
+                agent.AddComponent(new DtvAiComponent(agent));
             }
         }
 
@@ -136,7 +144,8 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
         for (int i = 0; i < extraBotsToSpawn; i += 1)
         {
             var group = groupsWithoutBoss[i % groupsWithoutBoss.Length];
-            SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
+            Agent agent = SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
+            agent.AddComponent(new DtvAiComponent(agent));
         }
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvSpawningBehavior.cs
@@ -133,7 +133,9 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
             for (int i = 0; i < groupBotCount; i++)
             {
                 Agent agent = SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
-                agent.AddComponent(new DtvAiComponent(agent));
+                DtvAiComponent component = new(agent);
+                agent.AddComponent(component);
+                component.Initialize();
             }
         }
 
@@ -145,7 +147,9 @@ internal class CrpgDtvSpawningBehavior : CrpgSpawningBehaviorBase
         {
             var group = groupsWithoutBoss[i % groupsWithoutBoss.Length];
             Agent agent = SpawnBotAgent(group.ClassDivisionId, Mission.AttackerTeam);
-            agent.AddComponent(new DtvAiComponent(agent));
+            DtvAiComponent component = new(agent);
+            agent.AddComponent(component);
+            component.Initialize();
         }
     }
 


### PR DESCRIPTION
DTV bots now have a timer (between 24 - 36 seconds) until they will target the viscount. The timer is reset when they either attack or get attacked by a defender. 

When bots first spawn the timer is 60 seconds

This is to reduce the amount of cheese possible in dtv by abusing bots' targetting unreachable players.

Difficulty is likely to spike significant from this change, so further balancing of bots (count / stats) may be required following feedback