### PR TITLE
mod: add tdm spawn frame behaviour for inital spawn locations

### DIFF
--- a/src/Module.Server/Common/CrpgSpawningBehaviorBase.cs
+++ b/src/Module.Server/Common/CrpgSpawningBehaviorBase.cs
@@ -258,7 +258,7 @@ private int totalNumberOfBots = 800;
         return characterObject;
     }
 
-    protected Agent SpawnBotAgent(string classDivisionId, Team team, MissionPeer? peer = null, int p = 0)
+    protected Agent SpawnBotAgent(string classDivisionId, Team team, MissionPeer? peer = null, int p = 0, bool isInitialSpawn = true)
     {
         var teamCulture = team.Side == BattleSideEnum.Attacker
             ? MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam1.GetStrValue())
@@ -270,7 +270,7 @@ private int totalNumberOfBots = 800;
         BasicCharacterObject character = botClass.HeroCharacter;
 
         bool hasMount = character.Equipment[EquipmentIndex.Horse].Item != null;
-        MatrixFrame spawnFrame = SpawnComponent.GetSpawnFrame(team, hasMount, true);
+        MatrixFrame spawnFrame = SpawnComponent.GetSpawnFrame(team, hasMount, isInitialSpawn);
         Vec2 initialDirection = spawnFrame.rotation.f.AsVec2.Normalized();
 
         AgentBuildData agentBuildData = new AgentBuildData(character)
@@ -330,7 +330,7 @@ private int totalNumberOfBots = 800;
         return agent;
     }
 
-    protected void SpawnBotAgents()
+    protected void SpawnBotAgents(bool isInitialSpawn = true)
     {
         int botsTeam1 = MultiplayerOptions.OptionType.NumberOfBotsTeam1.GetIntValue();
         int botsTeam2 = MultiplayerOptions.OptionType.NumberOfBotsTeam2.GetIntValue();
@@ -388,7 +388,7 @@ private int totalNumberOfBots = 800;
                 MultiplayerClassDivisions.MPHeroClass botClass = MultiplayerClassDivisions
                     .GetMPHeroClasses()
                     .GetRandomElementWithPredicate<MultiplayerClassDivisions.MPHeroClass>(x => x.StringId.StartsWith("crpg_bot_"));
-                SpawnBotAgent(botClass.StringId, team);
+                SpawnBotAgent(botClass.StringId, team, isInitialSpawn: isInitialSpawn);
             }
 
             k++;

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
@@ -96,7 +96,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
         CrpgTeamDeathmatchSpawningBehavior spawnBehavior = new(_constants);
         //MultiplayerRoundController roundController = new(); // starts/stops round, ends match
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent,
-            () => (new TeamDeathmatchSpawnFrameBehavior(), new CrpgTeamDeathmatchSpawningBehavior(_constants)));
+            () => (new CrpgTeamDeathmatchSpawnFrameBehavior(), new CrpgTeamDeathmatchSpawningBehavior(_constants)));
         CrpgTeamSelectServerComponent teamSelectComponent = new(warmupComponent, null, MultiplayerGameType.TeamDeathmatch);
         CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: true);
         CrpgTeamDeathmatchServer teamDeathmatchServer = new(scoreboardComponent, rewardServer);
@@ -139,7 +139,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
 #if CRPG_SERVER
                 teamDeathmatchServer,
                 rewardServer,
-                new SpawnComponent(new TeamDeathmatchSpawnFrameBehavior(), spawnBehavior),
+                new SpawnComponent(new CrpgTeamDeathmatchSpawnFrameBehavior(), spawnBehavior),
                 new AgentHumanAILogic(),
                 new MultiplayerAdminComponent(),
                 new CrpgUserManagerServer(crpgClient, _constants),

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchSpawnFrameBehavior.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchSpawnFrameBehavior.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.Modes.TeamDeathmatch;
+public class CrpgTeamDeathmatchSpawnFrameBehavior : SpawnFrameBehaviorBase
+{
+    private List<GameEntity>[] _spawnPointsByTeam = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _spawnPointsByTeam = new List<GameEntity>[2];
+        _spawnPointsByTeam[1] = SpawnPoints.Where((GameEntity x) => x.HasTag("attacker")).ToList();
+        _spawnPointsByTeam[0] = SpawnPoints.Where((GameEntity x) => x.HasTag("defender")).ToList();
+
+        if (_spawnPointsByTeam[0].Count < 1 | _spawnPointsByTeam[1].Count < 1) // If spawnpoints missing
+        {
+            _spawnPointsByTeam[0] = SpawnPoints.ToList();
+            _spawnPointsByTeam[1] = SpawnPoints.ToList();
+        }
+    }
+
+    public override MatrixFrame GetSpawnFrame(Team team, bool hasMount, bool isInitialSpawn)
+    {
+        List<GameEntity> spawnPoints = SpawnPoints.ToList();
+
+        if (isInitialSpawn)
+        {
+            spawnPoints = _spawnPointsByTeam[(int)team.Side];
+        }
+
+        return GetSpawnFrameFromSpawnPoints(spawnPoints, team, hasMount);
+    }
+}

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchSpawningBehavior.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchSpawningBehavior.cs
@@ -8,6 +8,7 @@ namespace Crpg.Module.Modes.TeamDeathmatch;
 
 internal class CrpgTeamDeathmatchSpawningBehavior : CrpgSpawningBehaviorBase
 {
+    private bool _haveBotsSpawned = false;
     public CrpgTeamDeathmatchSpawningBehavior(CrpgConstants constants)
         : base(constants)
     {
@@ -22,7 +23,7 @@ internal class CrpgTeamDeathmatchSpawningBehavior : CrpgSpawningBehaviorBase
         }
 
         SpawnAgents();
-        SpawnBotAgents();
+        SpawnBotAgents(!_haveBotsSpawned);
 
         TimeSinceSpawnEnabled += dt;
     }
@@ -41,7 +42,7 @@ internal class CrpgTeamDeathmatchSpawningBehavior : CrpgSpawningBehaviorBase
         {
             return false;
         }
-
+        _haveBotsSpawned = true;
         return true;
     }
 


### PR DESCRIPTION
Adds a TDM spawnframebehaviour to spawn players & bots into their respective 'attacker' and 'defender' spawnpoints for the first spawn.

Known issue that players joining mid-round will be forced to spawn once into those spawnpoints