### PR TITLE
mod: add firearm support for exporter & remove harmony module

### DIFF
--- a/src/Launcher/Program.cs
+++ b/src/Launcher/Program.cs
@@ -124,7 +124,7 @@ static GameInstallationInfo? ResolveBannerlordSteamInstallation()
             return new GameInstallationInfo(
                 bannerlordPath,
                 bannerlordExePath,
-                "_MODULES_*Bannerlord.Harmony*Native*Multiplayer*cRPG_Exporter*_MODULES_ /singleplayer /no_watchdog",
+                "_MODULES_*Native*Multiplayer*cRPG_Exporter*_MODULES_ /singleplayer /no_watchdog",
                 Path.GetDirectoryName(bannerlordExePath));
         }
     }

--- a/src/Module.Client/DataExport/IDataExporter.cs
+++ b/src/Module.Client/DataExport/IDataExporter.cs
@@ -7,6 +7,7 @@ public interface IDataExporter
     Task RefundArmor(string gitRepoPath);
     Task RefundWeapons(string gitRepoPath);
     Task RefundCrossbow(string gitRepoPath);
+    Task RefundFirearm(string gitRepoPath);
     Task RefundBow(string gitRepoPath);
     Task RefundThrowing(string gitRepoPath);
     Task RefundCav(string gitRepoPath);

--- a/src/Module.Client/DataExport/ItemExporter.cs
+++ b/src/Module.Client/DataExport/ItemExporter.cs
@@ -345,11 +345,6 @@ internal class ItemExporter : IDataExporter
             Flags = MbToCrpgItemFlags(mbItem.ItemFlags),
         };
 
-        if (mbItem.Type == ItemObject.ItemTypeEnum.Musket)
-        {
-
-        }
-
         if (mbItem.ArmorComponent != null)
         {
             crpgItem.Armor = new CrpgItemArmorComponent

--- a/src/Module.Client/DataExport/ItemExporter.cs
+++ b/src/Module.Client/DataExport/ItemExporter.cs
@@ -152,7 +152,24 @@ internal class ItemExporter : IDataExporter
         { 2, (16, 6) },
         { 3, (24, 9) },
     };
-
+    private static readonly Dictionary<int, (int damageBonus, int amountBonusPercentage)> BulletHeirloomBonus = new()
+    {
+        { 1, (1, 10) },
+        { 2, (2, 20) },
+        { 3, (3, 30) },
+    };
+    private static readonly Dictionary<int, (int damageBonus, int accuracyBonus, int missileSpeedBonus, int reloadSpeedBonus, int aimSpeedBonus)> MusketHeirloomBonus = new()
+    {
+        { 1, (1, 1, 0, 2, 1) },
+        { 2, (2, 2, 1, 4, 2) },
+        { 3, (3, 3, 2, 5, 3) },
+    };
+    private static readonly Dictionary<int, (int damageBonus, int accuracyBonus, int missileSpeedBonus, int reloadSpeedBonus, int aimSpeedBonus)> PistolHeirloomBonus = new()
+    {
+        { 1, (1, 1, 0, 2, 1) },
+        { 2, (2, 2, 1, 4, 2) },
+        { 3, (3, 3, 2, 5, 3) },
+    };
     public async Task ComputeAutoStats(string gitRepoPath)
     {
         foreach (string filePath in ItemFilePaths)
@@ -204,6 +221,20 @@ internal class ItemExporter : IDataExporter
         {
             ItemObject.ItemTypeEnum.Crossbow,
             ItemObject.ItemTypeEnum.Bolts,
+        };
+        var itemsDoc = XmlRefundItemType("../../Modules/cRPG_Exporter/ModuleData/items/weapons.xml", typesToRefund);
+        itemsDoc.Save(Path.Combine("../../Modules/cRPG_Exporter/ModuleData/items", Path.GetFileName("../../Modules/cRPG_Exporter/ModuleData/items/weapons.xml")));
+        var itemsDoc2 = XmlRefundItemType("../../Modules/cRPG_Exporter/ModuleData/items/weapons.xml", typesToRefund);
+        itemsDoc2.Save(Path.Combine("../../Modules/cRPG_Exporter/ModuleData/items", Path.GetFileName("../../Modules/cRPG_Exporter/ModuleData/items/weapons.xml")));
+    }
+
+    public async Task RefundFirearm(string gitRepoPath)
+    {
+        List<ItemObject.ItemTypeEnum> typesToRefund = new()
+        {
+            ItemObject.ItemTypeEnum.Musket,
+            ItemObject.ItemTypeEnum.Pistol,
+            ItemObject.ItemTypeEnum.Bullets,
         };
         var itemsDoc = XmlRefundItemType("../../Modules/cRPG_Exporter/ModuleData/items/weapons.xml", typesToRefund);
         itemsDoc.Save(Path.Combine("../../Modules/cRPG_Exporter/ModuleData/items", Path.GetFileName("../../Modules/cRPG_Exporter/ModuleData/items/weapons.xml")));
@@ -313,6 +344,11 @@ internal class ItemExporter : IDataExporter
             Requirement = CrpgItemRequirementModel.ComputeItemRequirement(mbItem),
             Flags = MbToCrpgItemFlags(mbItem.ItemFlags),
         };
+
+        if (mbItem.Type == ItemObject.ItemTypeEnum.Musket)
+        {
+
+        }
 
         if (mbItem.ArmorComponent != null)
         {
@@ -853,6 +889,15 @@ internal class ItemExporter : IDataExporter
 
                         break;
 
+                    case ItemObject.ItemTypeEnum.Bullets:
+                        if (BulletHeirloomBonus.TryGetValue(heirloomLevel, out var newBullet))
+                        {
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "thrust_damage", newBullet.damageBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "stack_amount", 0, bonusPercentage: newBullet.amountBonusPercentage);
+                        }
+
+                        break;
+
                     case ItemObject.ItemTypeEnum.Shield:
                         if (ShieldHeirloomBonus.TryGetValue(heirloomLevel, out var newShield))
                         {
@@ -913,6 +958,32 @@ internal class ItemExporter : IDataExporter
                                 ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "accuracy", newCrossbow.accuracyBonus);
                                 ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "missile_speed", newCrossbow.missileSpeedBonus);
                             }
+                        }
+
+                        break;
+
+                    case ItemObject.ItemTypeEnum.Musket:
+
+                        if (MusketHeirloomBonus.TryGetValue(heirloomLevel, out var newMusket))
+                        {
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "thrust_damage", newMusket.damageBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "speed_rating", newMusket.reloadSpeedBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "thrust_speed", newMusket.aimSpeedBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "accuracy", newMusket.accuracyBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "missile_speed", newMusket.missileSpeedBonus);
+                        }
+
+                        break;
+
+                    case ItemObject.ItemTypeEnum.Pistol:
+
+                        if (PistolHeirloomBonus.TryGetValue(heirloomLevel, out var newPistol))
+                        {
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "thrust_damage", newPistol.damageBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "speed_rating", newPistol.reloadSpeedBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "thrust_speed", newPistol.aimSpeedBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "accuracy", newPistol.accuracyBonus);
+                            ModifyChildHeirloomNodesAttribute(nonHeirloomNode, node1, "ItemComponent/Weapon", "missile_speed", newPistol.missileSpeedBonus);
                         }
 
                         break;

--- a/src/Module.Client/DataExport/SettlementExporter.cs
+++ b/src/Module.Client/DataExport/SettlementExporter.cs
@@ -116,6 +116,11 @@ internal class SettlementExporter : IDataExporter
         return Task.CompletedTask;
     }
 
+    public Task RefundFirearm(string gitRepoPath)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task RefundCrossbow(string gitRepoPath)
     {
         return Task.CompletedTask;

--- a/src/Module.Client/Module.Client.csproj
+++ b/src/Module.Client/Module.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <PlatformTarget>x64</PlatformTarget> <!-- avoids architecture mismatch warnings -->
     <RootNamespace>Crpg.Module</RootNamespace>
     <AssemblyName>CrpgExporter.Module</AssemblyName>

--- a/src/Module.Client/Module.Client.csproj
+++ b/src/Module.Client/Module.Client.csproj
@@ -94,7 +94,11 @@
     <Content Include="DataExport\ItemExporter.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Bannerlord.Lib.Harmony" Version="2.2.2" />
     <PackageReference Include="WindowsFirewallHelper" Version="2.2.0.86" />
+    <PackageReference Include="Lib.Harmony" Version="2.2.2" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(PkgLib_Harmony)\lib\netcoreapp3.1\0Harmony.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/Module.Client/Properties/launchSettings.json
+++ b/src/Module.Client/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "Module.Client": {
       "commandName": "Executable",
       "executablePath": "%MB_CLIENT_PATH%\\bin\\Win64_Shipping_Client\\Bannerlord.exe",
-      "commandLineArgs": "_MODULES_*Bannerlord.Harmony*Native*Multiplayer*cRPG_Exporter*_MODULES_ /singleplayer",
+      "commandLineArgs": "_MODULES_*Native*Multiplayer*cRPG_Exporter*_MODULES_ /singleplayer",
       "workingDirectory": "%MB_CLIENT_PATH%\\bin\\Win64_Shipping_Client"
     }
   }

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -74,6 +74,7 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             switch (weapon.CurrentUsageItem.WeaponClass)
             {
                 case WeaponClass.Bolt:
+                case WeaponClass.Cartridge:
                     finalDamage *= 2.5f;
                     break;
                 case WeaponClass.Arrow:

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -87,6 +87,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
             WeaponClass.Bow => 1.25f,
             WeaponClass.Crossbow => 0.5f,
             WeaponClass.Musket => 0.5f,
+            WeaponClass.Pistol => 0.5f,
             WeaponClass.Stone => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1f,
             WeaponClass.ThrowingAxe => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForSwingThrowing / 30f, 2f) * 1.65f,
             WeaponClass.ThrowingKnife => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.65f,

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -86,6 +86,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         {
             WeaponClass.Bow => 1.25f,
             WeaponClass.Crossbow => 0.5f,
+            WeaponClass.Musket => 0.5f,
             WeaponClass.Stone => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1f,
             WeaponClass.ThrowingAxe => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForSwingThrowing / 30f, 2f) * 1.65f,
             WeaponClass.ThrowingKnife => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.65f,

--- a/src/Module.Server/Common/Models/CrpgItemRequirementModel.cs
+++ b/src/Module.Server/Common/Models/CrpgItemRequirementModel.cs
@@ -16,6 +16,8 @@ internal class CrpgItemRequirementModel
         switch (item.ItemType)
         {
             case ItemObject.ItemTypeEnum.Crossbow:
+            case ItemObject.ItemTypeEnum.Musket:
+            case ItemObject.ItemTypeEnum.Pistol:
                 return ComputeCrossbowRequirement(item);
         }
 
@@ -26,10 +28,10 @@ internal class CrpgItemRequirementModel
     {
         int strengthRequirementForTierTenCrossbow;
 
-        // Check if the item is a crossbow
-        if (item.ItemType != ItemObject.ItemTypeEnum.Crossbow)
+        // Check if the item is a crossbow or firearm
+        if (item.ItemType != ItemObject.ItemTypeEnum.Crossbow && item.ItemType != ItemObject.ItemTypeEnum.Musket && item.ItemType != ItemObject.ItemTypeEnum.Pistol)
         {
-            throw new ArgumentException(item.Name.ToString() + " is not a crossbow");
+            throw new ArgumentException(item.Name.ToString() + " is not a crossbow or firearm");
         }
 
         // Adjust the strength requirement for light crossbows

--- a/src/Module.Server/Common/Models/CrpgItemValueModel.cs
+++ b/src/Module.Server/Common/Models/CrpgItemValueModel.cs
@@ -29,12 +29,15 @@ internal class CrpgItemValueModel : ItemValueModel
         [ItemObject.ItemTypeEnum.Shield] = (5000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Bow] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Crossbow] = (14000, ItemPriceCoeffs),
+        [ItemObject.ItemTypeEnum.Musket] = (14000, ItemPriceCoeffs),
+        [ItemObject.ItemTypeEnum.Pistol] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.OneHandedWeapon] = (9000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.TwoHandedWeapon] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Polearm] = (14000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Thrown] = (6000, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Arrows] = (4500, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Bolts] = (4500, ItemPriceCoeffs),
+        [ItemObject.ItemTypeEnum.Bullets] = (4500, ItemPriceCoeffs),
         [ItemObject.ItemTypeEnum.Banner] = (500, ItemPriceCoeffs),
     };
     public static float ComputeBowTier(int damage, int reloadSpeed, int missileSpeed, int aimSpeed, int accuracy, bool isLongBow, float heirloomLevel)
@@ -391,7 +394,7 @@ internal class CrpgItemValueModel : ItemValueModel
     {
         WeaponComponentData weapon = weaponComponent.Weapons[0];
         float heirloomLevel = ItemToHeirloomLevel(weaponComponent.Item);
-        if (weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Crossbow })
+        if (weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Crossbow } || weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Musket })
         {
             float crossbowscaler = 1.5f;
             float crossbowTier = weapon.ThrustDamage / 100f * weapon.ThrustDamage / 100f
@@ -450,6 +453,7 @@ internal class CrpgItemValueModel : ItemValueModel
             ItemObject.ItemTypeEnum.Arrows => arrowsTier * arrowsTier / 10f,
 
             ItemObject.ItemTypeEnum.Bolts => boltsTier * boltsTier / 10f,
+            ItemObject.ItemTypeEnum.Bullets => boltsTier * boltsTier / 10f,
             _ => 10f,
         };
     }

--- a/src/Module.Server/Common/Models/CrpgItemValueModel.cs
+++ b/src/Module.Server/Common/Models/CrpgItemValueModel.cs
@@ -394,7 +394,7 @@ internal class CrpgItemValueModel : ItemValueModel
     {
         WeaponComponentData weapon = weaponComponent.Weapons[0];
         float heirloomLevel = ItemToHeirloomLevel(weaponComponent.Item);
-        if (weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Crossbow } || weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Musket })
+        if (weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Crossbow } || weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Musket } || weaponComponent.Item is { ItemType: ItemObject.ItemTypeEnum.Pistol })
         {
             float crossbowscaler = 1.5f;
             float crossbowTier = weapon.ThrustDamage / 100f * weapon.ThrustDamage / 100f

--- a/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
+++ b/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
@@ -114,6 +114,7 @@ internal class CrpgStrikeMagnitudeModel : MultiplayerStrikeMagnitudeModel
         {
             WeaponClass.Arrow => 1.2f,
             WeaponClass.Bolt => 0.9f,
+            WeaponClass.Cartridge => 0.9f,
             WeaponClass.Stone => 0.95f,
             WeaponClass.Boulder => 0.9f,
             WeaponClass.ThrowingAxe => 1.3f,

--- a/src/Module.Server/CrpgSubModule.cs
+++ b/src/Module.Server/CrpgSubModule.cs
@@ -235,6 +235,23 @@ internal class CrpgSubModule : MBSubModuleBase
         }
     }
 
+    private void RefundFirearm()
+    {
+        IDataExporter[] exporters =
+        {
+            new ItemExporter(),
+            // new SettlementExporter(),
+        };
+
+        InformationManager.DisplayMessage(new InformationMessage("Refunding Firearms."));
+        Task.WhenAll(exporters.Select(e => e.RefundFirearm("lol"))).ContinueWith(t =>
+        {
+            InformationManager.DisplayMessage(t.IsFaulted
+                ? new InformationMessage(t.Exception!.Message)
+                : new InformationMessage("Firearms were refunded"));
+        });
+    }
+
     private void RefundCrossbow()
     {
         IDataExporter[] exporters =
@@ -463,6 +480,9 @@ internal class CrpgSubModule : MBSubModuleBase
             case 6:
                 RefundWeapons();
                 break;
+            case 7:
+                RefundFirearm();
+                break;
             default:
                 throw new ArgumentException("Invalid argument for 'toRefund'");
         }
@@ -470,7 +490,7 @@ internal class CrpgSubModule : MBSubModuleBase
 
     private void ChangeRefund()
     {
-        _toRefund = (_toRefund + 1) % 7;
+        _toRefund = (_toRefund + 1) % 8;
         string message = _toRefund switch
         {
             0 => "Refund Crossbows",
@@ -479,7 +499,8 @@ internal class CrpgSubModule : MBSubModuleBase
             3 => "Refund Shields",
             4 => "Refund Armors",
             5 => "Refund Cav",
-            6 => "Refund Weapons"
+            6 => "Refund Weapons",
+            7 => "Refund firearms"
         }
 
         + " has been selected";

--- a/src/Module.Server/SubModule.xml
+++ b/src/Module.Server/SubModule.xml
@@ -7,7 +7,6 @@
   <DependedModules>
     <DependedModule Id="Native" DependentVersion="v1.2.12" Optional="false"/>
     <DependedModule Id="Multiplayer" DependentVersion="v1.2.12" Optional="false"/>
-    <DependedModule Id="Bannerlord.Harmony" DependentVersion="v2.10.1" />
   </DependedModules>
   <SubModules>
     <SubModule>


### PR DESCRIPTION
Adds support for Musket & Pistol type & weapon classes
Adds support for Bullets type
Adds support for Cartridge weapon class
Removes Bannerlord.Harmony module, replaced with Lib.Harmony 2.2.2 so crafters do not need to rely on harmony installation.