### PR TITLE
mod: add axes slicedthrough meleecollisionreaction

### DIFF
--- a/src/Module.Server/HarmonyPatches/DecideWeaponCollisionReactionPatch.cs
+++ b/src/Module.Server/HarmonyPatches/DecideWeaponCollisionReactionPatch.cs
@@ -1,0 +1,25 @@
+﻿using HarmonyLib;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.HarmonyPatches;
+
+[HarmonyPatch]
+public class DecideWeaponCollisionReactionPatch
+{
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(Mission), "DecideWeaponCollisionReaction")]
+    public static void AddAxeSlicedThrough(ref MeleeCollisionReaction colReaction, in MissionWeapon attackerWeapon, in AttackCollisionData collisionData)
+    {
+        // Check if the weapon used for the attack is an axe
+        var weaponClass = attackerWeapon.IsEmpty ? WeaponClass.Undefined : attackerWeapon.CurrentUsageItem.WeaponClass;
+        bool isAxe = weaponClass == WeaponClass.OneHandedAxe || weaponClass == WeaponClass.TwoHandedAxe;
+        // Check if the attack hit an enemy (not a shield or an obstacle)
+        bool hitEnemy = collisionData.IsColliderAgent && !collisionData.AttackBlockedWithShield;
+        // Modify the collision reaction if the conditions are met
+        if (isAxe && hitEnemy && colReaction != MeleeCollisionReaction.SlicedThrough)
+        {
+            colReaction = MeleeCollisionReaction.SlicedThrough;
+        }
+    }
+}


### PR DESCRIPTION
Adds harmony postfix to set `MeleeCollisionReaction` for axes to `MeleeCollisionReaction.SlicedThrough` when hitting an agent.