### PR TITLE
fix: patch crash when more than one NetworkPeer found with VirtualPlayer.Id

### DIFF
--- a/src/Module.Server/HarmonyPatches/HandleClientQuitFromCustomGamePatch.cs
+++ b/src/Module.Server/HarmonyPatches/HandleClientQuitFromCustomGamePatch.cs
@@ -28,8 +28,7 @@ public class HandleClientQuitFromCustomGamePatch
             {
                 networkCommunicator.QuitFromMission = true;
                 GameNetwork.AddNetworkPeerToDisconnectAsServer(networkCommunicator);
-                string text = "player with id ";
-                MBDebug.Print(text + playerId.ToString() + " quit from game");
+                MBDebug.Print("player with id " + playerId.ToString() + " quit from game");
             }
         });
 

--- a/src/Module.Server/HarmonyPatches/HandleClientQuitFromCustomGamePatch.cs
+++ b/src/Module.Server/HarmonyPatches/HandleClientQuitFromCustomGamePatch.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.DedicatedCustomServer;
+using TaleWorlds.PlayerServices;
+
+namespace Crpg.Module.HarmonyPatches;
+
+[HarmonyPatch]
+public class HandleClientQuitFromCustomGamePatch
+{
+#if CRPG_SERVER
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(DedicatedCustomGameServerHandler), "HandleClientQuitFromCustomGame")]
+    public static bool Prefix(PlayerId playerId)
+    {
+        Task.Run(async () =>
+        {
+            while (Mission.Current != null && Mission.Current.CurrentState != Mission.State.Continuing)
+            {
+                await Task.Delay(1);
+            }
+
+            NetworkCommunicator networkCommunicator = GameNetwork.NetworkPeers.FirstOrDefault((NetworkCommunicator x) => x.VirtualPlayer.Id == playerId);
+            if (networkCommunicator != null && !networkCommunicator.IsServerPeer)
+            {
+                networkCommunicator.QuitFromMission = true;
+                GameNetwork.AddNetworkPeerToDisconnectAsServer(networkCommunicator);
+                string text = "player with id ";
+                MBDebug.Print(text + playerId.ToString() + " quit from game");
+            }
+        });
+
+        return false;
+    }
+#endif
+}


### PR DESCRIPTION
```Application: DedicatedCustomServer.Starter.exe
CoreCLR Version: 6.0.1222.56807
.NET Version: 6.0.12
Description: The process was terminated due to an unhandled exception.
Exception Info: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Sequence contains more than one matching element
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at TaleWorlds.MountAndBlade.DedicatedCustomServer.DedicatedCustomGameServerHandler.HandleClientQuitFromCustomGame(PlayerId playerId)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at TaleWorlds.Library.Common.DynamicInvokeWithLog(Delegate method, Object[] args)
   at TaleWorlds.Library.SingleThreadedSynchronizationContext.Tick()
   at TaleWorlds.MountAndBlade.Module.OnApplicationTick(Single dt)
   at TaleWorlds.DotNet.Managed.ApplicationTick(Single dt)```