### PR TITLE
mod: remove extra slot from spawn weapon check

### DIFF
--- a/src/Module.Server/Common/CrpgSpawningBehaviorBase.cs
+++ b/src/Module.Server/Common/CrpgSpawningBehaviorBase.cs
@@ -409,9 +409,9 @@ private int totalNumberOfBots = 800;
 
     protected bool DoesEquipmentContainWeapon(Equipment equipment)
     {
-        foreach (var weaponClass in allowedSpawnWeaponClass)
+        for (var i = EquipmentIndex.Weapon0; i <= EquipmentIndex.Weapon3; i += 1)
         {
-            if (equipment.HasWeaponOfClass(weaponClass))
+            if (!equipment[i].IsEmpty && allowedSpawnWeaponClass.Contains(equipment[i].Item.PrimaryWeapon.WeaponClass))
             {
                 return true;
             }


### PR DESCRIPTION
Removes the extra weapon slot from being checked for a valid melee or throwing weapon to spawn. 

closes #482 