### PR TITLE
mod: modify economy and rewards

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -16,7 +16,7 @@
   "multipliedExperienceGainPerSecond": 13.9,
   "baseGoldGainPerSecond": 0.66,
   "multipliedGoldGainPerSecond": 0.66,
-  "itemRepairCostPerSecond": 0.0001148,
+  "itemRepairCostPerSecond": 0.00012554,
   "itemBreakChance": 0.5,
   "brokenItemRepairPenaltySeconds": 300,
   "itemSellCostPenalty": 0.5,

--- a/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
@@ -19,6 +19,7 @@ internal class CrpgBattleServer : MissionMultiplayerGameModeBase
     private const float BattleMoraleGainMultiplierLastFlag = 2f;
     private const float SkirmishMoraleGainOnTick = 0.00125f;
     private const float SkirmishMoraleGainMultiplierLastFlag = 2f;
+    private const int LossMultiplier = 2;
 
     private readonly CrpgBattleClient _battleClient;
     private readonly MultiplayerGameType _gametype;
@@ -399,8 +400,8 @@ internal class CrpgBattleServer : MissionMultiplayerGameModeBase
         var roundWinner = RoundController.RoundWinner;
         _ = _rewardServer.UpdateCrpgUsersAsync(
             durationRewarded: roundDuration,
-            defenderMultiplierGain: roundWinner == BattleSideEnum.Defender ? 1 : -CrpgRewardServer.ExperienceMultiplierMax,
-            attackerMultiplierGain: roundWinner == BattleSideEnum.Attacker ? 1 : -CrpgRewardServer.ExperienceMultiplierMax,
+            defenderMultiplierGain: roundWinner == BattleSideEnum.Defender ? 1 : -LossMultiplier,
+            attackerMultiplierGain: roundWinner == BattleSideEnum.Attacker ? 1 : -LossMultiplier,
             valourTeamSide: roundWinner.GetOppositeSide());
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -17,7 +17,7 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private const int RewardMultiplier = 2;
     private const int MapDuration = 60 * 120;
 
-    private const float UpkeepMultiplier = 0.75f;
+    private const float UpkeepMultiplier = 0.80f;
     private const int BoulderRefillTime = 30;
     private const int FirePotRefillTime = 60;
 

--- a/src/Module.Server/ModuleData/dtv/dtv_data.xml
+++ b/src/Module.Server/ModuleData/dtv/dtv_data.xml
@@ -191,7 +191,7 @@
     </Wave>
   </Round>
 
-  <Round reward="470">
+  <Round reward="460">
     <Wave>
       <Group classDivisionId="crpg_dtv_legion_soldier" count="1.7" />
       <Group classDivisionId="crpg_dtv_legion_archer" count="0.7" />
@@ -215,7 +215,7 @@
     </Wave>
   </Round>
 
-  <Round reward="495">
+  <Round reward="475">
     <Wave>
       <Group classDivisionId="crpg_dtv_reconquista_skirmisher" count="1.5" />
       <Group classDivisionId="crpg_dtv_reconquista_explorer" count="0.5" />
@@ -240,7 +240,7 @@
     </Wave>
   </Round>
 
-  <Round reward="520">
+  <Round reward="500">
     <Wave>
       <Group classDivisionId="crpg_dtv_aserai_warrior" count="1.8" />
       <Group classDivisionId="crpg_dtv_aserai_archer" count="0.5" />
@@ -260,7 +260,7 @@
     </Wave>
   </Round>
 
-  <Round reward="565">
+  <Round reward="540">
     <Wave>
       <Group classDivisionId="crpg_dtv_highland_ranger" count="0.8" />
       <Group classDivisionId="crpg_dtv_highland_soldier" count="1.5" />
@@ -280,7 +280,7 @@
     </Wave>
   </Round>
   
-  <Round reward="620">
+  <Round reward="600">
     <Wave>
       <Group classDivisionId="crpg_dtv_varangian_recruit" count="1.8" />
       <Group classDivisionId="crpg_dtv_varangian_guard" count="0.5" />
@@ -303,7 +303,7 @@
     </Wave>
   </Round>
 
-  <Round reward="700">
+  <Round reward="680">
     <Wave>
       <Group classDivisionId="crpg_dtv_khuzait_soldier" count="1.5" />
       <Group classDivisionId="crpg_dtv_khuzait_horseman" count="0.5" />
@@ -321,7 +321,7 @@
     </Wave>
   </Round>
 
-  <Round reward="805">
+  <Round reward="760">
     <Wave>
       <Group classDivisionId="crpg_dtv_dwarven_engineer" count="0.8" />
       <Group classDivisionId="crpg_dtv_dwarven_axelord" count="0.7" />
@@ -342,7 +342,7 @@
     </Wave>
   </Round>
 
-  <Round reward="870">
+  <Round reward="830">
     <Wave>
       <Group classDivisionId="crpg_dtv_greyorder_shielder" count="1.0" />
       <Group classDivisionId="crpg_dtv_greyorder_kuyak_two_handed" count="0.4" />
@@ -367,7 +367,7 @@
     </Wave>
   </Round>
 
-  <Round reward="930">
+  <Round reward="890">
     <Wave>
       <Group classDivisionId="crpg_dtv_tincan_soldier" count="2.0" />
       <Group classDivisionId="crpg_dtv_tincan_archer" count="1.0" />

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -609,7 +609,7 @@ internal class CrpgRewardServer : MissionLogic
             }
         }
 
-        int numberOfPlayersToGiveValour = (defeatedTeamPlayersWithRoundScore.Count is >= 3 and <= 5)
+        int numberOfPlayersToGiveValour = (defeatedTeamPlayersWithRoundScore.Count is >= 2 and <= 5)
             ? 1
             : (int)(0.2f * defeatedTeamPlayersWithRoundScore.Count);
         Debug.Print($"Giving valour to {numberOfPlayersToGiveValour} out of the {defeatedTeamPlayersWithRoundScore.Count} players in the defeated team");


### PR DESCRIPTION
- Multiplier when losing in battle is now reduced by 2x instead of 5x
- Valour will now be awarded on teams with 2 or more players
- Increase upkeep by ~9%
- Reduced DTV Upkeep discount from 25% to 20%
- Reduced DTV rewards in higher rounds by around 5%