### PR TITLE
Changed cartridge pen to 0.8

### DIFF
--- a/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
+++ b/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
@@ -114,7 +114,7 @@ internal class CrpgStrikeMagnitudeModel : MultiplayerStrikeMagnitudeModel
         {
             WeaponClass.Arrow => 1.2f,
             WeaponClass.Bolt => 0.9f,
-            WeaponClass.Cartridge => 0.9f,
+            WeaponClass.Cartridge => 0.8f,
             WeaponClass.Stone => 0.95f,
             WeaponClass.Boulder => 0.9f,
             WeaponClass.ThrowingAxe => 1.3f,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9f94dd81-40f1-44fb-bce6-fea587c7b6cc)

Buffed cartridge penetration to 0.8, to help diversify guns from crossbows. A 2 damage increase for shooting targets >40 armor, a 1 damage increase for shooting targets <30 armor. Highest damage xbow + highest damage bolts still most damaging (at least up to 100 armor).

The cons of the gun over the xbow (harder to aim, smoke giving away posistion, less abusable reload) the buff not being accounted for in budget seems fair.

I'm not convinced it's as weak as some of the feedback we've received makes out - certainly on the STR req front. Dropping to 18STR would too easily allow enough WPF to be very competent in melee and the gun, at which point I think it would objectively be too powerful.