### PR TITLE
mod: warmup overhaul

### DIFF
--- a/src/Module.Client/GUI/HudExtension/CrpgHudExtensionHandler.cs
+++ b/src/Module.Client/GUI/HudExtension/CrpgHudExtensionHandler.cs
@@ -1,4 +1,5 @@
-﻿using TaleWorlds.Core;
+﻿using Crpg.Module.Modes.Warmup;
+using TaleWorlds.Core;
 using TaleWorlds.Engine.GauntletUI;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View;
@@ -17,10 +18,21 @@ internal class CrpgHudExtensionHandler : MissionView
     private GauntletLayer? _gauntletLayer;
     private SpriteCategory? _mpMissionCategory;
     private MissionLobbyComponent? _lobbyComponent;
+    private CrpgWarmupComponent? _warmupComponent;
 
     public CrpgHudExtensionHandler()
     {
         ViewOrderPriority = 2;
+    }
+
+    public override void AfterStart()
+    {
+        base.AfterStart();
+        _warmupComponent = Mission.GetMissionBehavior<CrpgWarmupComponent>();
+        if (_warmupComponent != null)
+        {
+            _warmupComponent.OnUpdatePlayerCount += OnUpdatePlayerCount;
+        }
     }
 
     public override void OnMissionScreenInitialize()
@@ -53,6 +65,10 @@ internal class CrpgHudExtensionHandler : MissionView
         _gauntletLayer = null;
         Game.Current.EventManager.UnregisterEvent<MissionPlayerToggledOrderViewEvent>(OnMissionPlayerToggledOrderViewEvent);
         base.OnMissionScreenFinalize();
+        if (_warmupComponent != null)
+        {
+            _warmupComponent.OnUpdatePlayerCount -= OnUpdatePlayerCount;
+        }
     }
 
     public override void OnMissionScreenTick(float dt)
@@ -69,5 +85,10 @@ internal class CrpgHudExtensionHandler : MissionView
     private void OnPostMatchEnded()
     {
         _dataSource!.ShowHud = false;
+    }
+
+    private void OnUpdatePlayerCount(int requiredPlayers)
+    {
+        _dataSource!.OnUpdateRequiredPlayers(requiredPlayers);
     }
 }

--- a/src/Module.Client/GUI/HudExtension/CrpgHudExtensionVm.cs
+++ b/src/Module.Client/GUI/HudExtension/CrpgHudExtensionVm.cs
@@ -51,6 +51,7 @@ internal class CrpgHudExtensionVm : ViewModel
     private bool _isGeneralWarningCountdownActive;
     private ImageIdentifierVM? _allyBanner;
     private ImageIdentifierVM? _enemyBanner;
+    private int _requiredPlayers;
 
     public CrpgHudExtensionVm(Mission mission)
     {
@@ -580,8 +581,9 @@ internal class CrpgHudExtensionVm : ViewModel
     {
         base.RefreshValues();
         string strValue = MultiplayerOptions.OptionType.GameType.GetStrValue();
-        TextObject textObject = new("{=XJTX8w8M}Warmup Phase - {GAME_MODE}\nWaiting for players to join");
+        TextObject textObject = new("{=XJTX8w8Q}Warmup Phase - {GAME_MODE}\nWaiting for {PLAYERS} player(s) to join");
         textObject.SetTextVariable("GAME_MODE", GameTexts.FindText("str_multiplayer_official_game_type_name", strValue));
+        textObject.SetTextVariable("PLAYERS", _requiredPlayers);
         WarmupInfoText = textObject.ToString();
         SpectatorControls!.RefreshValues();
     }
@@ -636,6 +638,12 @@ internal class CrpgHudExtensionVm : ViewModel
         {
             ReflectionHelper.InvokeMethod(_spectatorControls, "OnSpectatedAgentFocusOut", new object[] { followedPeer });
         }
+    }
+
+    public void OnUpdateRequiredPlayers(int requiredPlayers)
+    {
+        _requiredPlayers = requiredPlayers;
+        RefreshValues();
     }
 
     private void OnMissionReset(object sender, PropertyChangedEventArgs e)

--- a/src/Module.Client/GUI/Warmup/WarmupHudUiHandler.cs
+++ b/src/Module.Client/GUI/Warmup/WarmupHudUiHandler.cs
@@ -1,6 +1,4 @@
-﻿using Crpg.Module.Common.Commander;
-using Crpg.Module.Modes.Dtv;
-using Crpg.Module.Modes.Warmup;
+﻿using Crpg.Module.Modes.Warmup;
 using TaleWorlds.Engine.GauntletUI;
 using TaleWorlds.MountAndBlade.View.MissionViews;
 

--- a/src/Module.Client/GUI/Warmup/WarmupHudUiHandler.cs
+++ b/src/Module.Client/GUI/Warmup/WarmupHudUiHandler.cs
@@ -1,4 +1,7 @@
-﻿using TaleWorlds.Engine.GauntletUI;
+﻿using Crpg.Module.Common.Commander;
+using Crpg.Module.Modes.Dtv;
+using Crpg.Module.Modes.Warmup;
+using TaleWorlds.Engine.GauntletUI;
 using TaleWorlds.MountAndBlade.View.MissionViews;
 
 namespace Crpg.Module.GUI.Warmup;
@@ -7,6 +10,17 @@ internal class WarmupHudUiHandler : MissionView
 {
     private WarmupHudVm? _dataSource;
     private GauntletLayer? _gauntletLayer;
+    private CrpgWarmupComponent? _warmupComponent;
+
+    public override void AfterStart()
+    {
+        base.AfterStart();
+        _warmupComponent = Mission.GetMissionBehavior<CrpgWarmupComponent>();
+        if (_warmupComponent != null)
+        {
+            _warmupComponent.OnUpdatePlayerCount += OnUpdatePlayerCount;
+        }
+    }
 
     public override void OnMissionScreenInitialize()
     {
@@ -23,11 +37,20 @@ internal class WarmupHudUiHandler : MissionView
         MissionScreen.RemoveLayer(_gauntletLayer);
         _dataSource!.OnFinalize();
         base.OnMissionScreenFinalize();
+        if (_warmupComponent != null)
+        {
+            _warmupComponent.OnUpdatePlayerCount -= OnUpdatePlayerCount;
+        }
     }
 
     public override void OnMissionScreenTick(float dt)
     {
         base.OnMissionScreenTick(dt);
         _dataSource!.Tick(dt);
+    }
+
+    private void OnUpdatePlayerCount(int requiredPlayers)
+    {
+        _dataSource!.OnUpdateRequiredPlayers(requiredPlayers);
     }
 }

--- a/src/Module.Client/GUI/Warmup/WarmupHudVm.cs
+++ b/src/Module.Client/GUI/Warmup/WarmupHudVm.cs
@@ -10,6 +10,7 @@ internal class WarmupHudVm : ViewModel
     private readonly MissionMultiplayerGameModeBaseClient _gameMode;
 
     private string? _warmupInfoText;
+    private int _requiredPlayers;
     private bool _isInWarmup;
 
     public WarmupHudVm(Mission mission)
@@ -57,13 +58,20 @@ internal class WarmupHudVm : ViewModel
         base.RefreshValues();
 
         string gameType = MultiplayerOptions.OptionType.GameType.GetStrValue();
-        TextObject textObject = new("{=XJTX8w8M}Warmup Phase - {GAME_MODE}\nWaiting for players to join");
+        TextObject textObject = new("{=XJTX8w8M}Warmup Phase - {GAME_MODE}\nWaiting for {PLAYERS} player(s) to join");
         textObject.SetTextVariable("GAME_MODE", GameTexts.FindText("str_multiplayer_official_game_type_name", gameType));
+        textObject.SetTextVariable("PLAYERS", _requiredPlayers);
         WarmupInfoText = textObject.ToString();
     }
 
     public void Tick(float dt)
     {
         IsInWarmup = _gameMode.IsInWarmup;
+    }
+
+    public void OnUpdateRequiredPlayers(int requiredPlayers)
+    {
+        _requiredPlayers = requiredPlayers;
+        RefreshValues();
     }
 }

--- a/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
@@ -125,7 +125,7 @@ internal class CrpgBattleServer : MissionMultiplayerGameModeBase
             }
         }
 
-        return playersInTeam >= MultiplayerOptions.OptionType.MaxNumberOfPlayers.GetIntValue();
+        return playersInTeam >= MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue();
     }
 
     public override void OnMissionTick(float dt)

--- a/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
@@ -171,7 +171,17 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
 
     public override bool CheckForWarmupEnd()
     {
-        return false;
+        int playersInTeam = 0;
+        foreach (NetworkCommunicator networkPeer in GameNetwork.NetworkPeers)
+        {
+            MissionPeer component = networkPeer.GetComponent<MissionPeer>();
+            if (networkPeer.IsSynchronized && component?.Team != null && component.Team.Side != BattleSideEnum.None)
+            {
+                playersInTeam += 1;
+            }
+        }
+
+        return playersInTeam >= MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue();
     }
 
     public override void OnClearScene()

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -92,7 +92,17 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
 
     public override bool CheckForWarmupEnd()
     {
-        return true;
+        int playersInTeam = 0;
+        foreach (NetworkCommunicator networkPeer in GameNetwork.NetworkPeers)
+        {
+            MissionPeer component = networkPeer.GetComponent<MissionPeer>();
+            if (networkPeer.IsSynchronized && component?.Team != null && component.Team.Side != BattleSideEnum.None)
+            {
+                playersInTeam += 1;
+            }
+        }
+
+        return playersInTeam >= MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue();
     }
 
     public override void OnPeerChangedTeam(NetworkCommunicator networkPeer, Team oldTeam, Team newTeam)
@@ -175,6 +185,11 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
 
     public void RewardIfEndOfMission(MissionLobbyComponent.MultiplayerGameState newState)
     {
+        if (!_gameStarted)
+        {
+            return;
+        }
+
         if (!_timerExpired && TimerComponent.CheckIfTimerPassed() && newState == MissionLobbyComponent.MultiplayerGameState.Ending) // Award players if timer expires
         {
             _timerExpired = true;

--- a/src/Module.Server/Modes/Siege/CrpgSiegeServer.cs
+++ b/src/Module.Server/Modes/Siege/CrpgSiegeServer.cs
@@ -136,17 +136,17 @@ internal class CrpgSiegeServer : MissionMultiplayerGameModeBase, IAnalyticsFlagI
 
     public override bool CheckForWarmupEnd()
     {
-        int playersReady = 0;
+        int playersInTeam = 0;
         foreach (NetworkCommunicator networkPeer in GameNetwork.NetworkPeers)
         {
             MissionPeer component = networkPeer.GetComponent<MissionPeer>();
             if (networkPeer.IsSynchronized && component?.Team != null && component.Team.Side != BattleSideEnum.None)
             {
-                playersReady += 1;
+                playersInTeam += 1;
             }
         }
 
-        return playersReady >= MultiplayerOptions.OptionType.MaxNumberOfPlayers.GetIntValue();
+        return playersInTeam >= MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue();
     }
 
     public override void OnClearScene()

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchServer.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchServer.cs
@@ -72,6 +72,21 @@ internal class CrpgTeamDeathmatchServer : MissionMultiplayerGameModeBase
         }
     }
 
+    public override bool CheckForWarmupEnd()
+    {
+        int playersInTeam = 0;
+        foreach (NetworkCommunicator networkPeer in GameNetwork.NetworkPeers)
+        {
+            MissionPeer component = networkPeer.GetComponent<MissionPeer>();
+            if (networkPeer.IsSynchronized && component?.Team != null && component.Team.Side != BattleSideEnum.None)
+            {
+                playersInTeam += 1;
+            }
+        }
+
+        return playersInTeam >= MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue();
+    }
+
     public override bool CheckForMatchEnd()
     {
         int minScoreToWinMatch = MultiplayerOptions.OptionType.MinScoreToWinMatch.GetIntValue();

--- a/src/Module.Server/Modes/Warmup/CrpgWarmupComponent.cs
+++ b/src/Module.Server/Modes/Warmup/CrpgWarmupComponent.cs
@@ -1,15 +1,12 @@
 ﻿using System.Reflection;
 using Crpg.Module.Common;
-using Crpg.Module.Common.Network;
 using Crpg.Module.Helpers;
 using Crpg.Module.Modes.Battle;
 using NetworkMessages.FromServer;
 using TaleWorlds.Core;
-using TaleWorlds.Diamond;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.MountAndBlade.MultiplayerWarmupComponent;
 
 namespace Crpg.Module.Modes.Warmup;
 
@@ -58,7 +55,7 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
                 GameNetwork.WriteMessage(new WarmupStateChange(WarmupStateReflection, _currentStateStartTime.NumberOfTicks));
                 GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
             }
-        } 
+        }
     }
 
     private MultiplayerTimerComponent TimerComponentReflection => (MultiplayerTimerComponent)TimerComponentField.GetValue(this)!;
@@ -74,12 +71,6 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
     {
         base.OnRemoveBehavior();
         MissionPeer.OnTeamChanged -= HandlePeerTeamChanged;
-    }
-
-    protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)
-    {
-        base.AddRemoveMessageHandlers(registerer);
-        registerer.Register<WarmupStateChange>(HandleServerEventWarmupStateChange);
     }
 
     public override void OnPreDisplayMissionTick(float dt)
@@ -130,6 +121,14 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
 
         RewardUsers();
     }
+
+
+    protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)
+    {
+        base.AddRemoveMessageHandlers(registerer);
+        registerer.Register<WarmupStateChange>(HandleServerEventWarmupStateChange);
+    }
+
     protected override void HandleNewClientAfterSynchronized(NetworkCommunicator networkPeer)
     {
         if (IsInWarmup && !networkPeer.IsServerPeer)

--- a/src/Module.Server/Modes/Warmup/CrpgWarmupComponent.cs
+++ b/src/Module.Server/Modes/Warmup/CrpgWarmupComponent.cs
@@ -1,8 +1,15 @@
 ﻿using System.Reflection;
 using Crpg.Module.Common;
+using Crpg.Module.Common.Network;
 using Crpg.Module.Helpers;
 using Crpg.Module.Modes.Battle;
+using NetworkMessages.FromServer;
+using TaleWorlds.Core;
+using TaleWorlds.Diamond;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
+using static TaleWorlds.MountAndBlade.MultiplayerWarmupComponent;
 
 namespace Crpg.Module.Modes.Warmup;
 
@@ -11,6 +18,8 @@ namespace Crpg.Module.Modes.Warmup;
 /// </summary>
 internal class CrpgWarmupComponent : MultiplayerWarmupComponent
 {
+    private const float WarmupRewardTimer = 30f;
+
     private static readonly FieldInfo WarmupStateField = typeof(MultiplayerWarmupComponent)
         .GetField("_warmupState", BindingFlags.NonPublic | BindingFlags.Instance)!;
     private static readonly FieldInfo TimerComponentField = typeof(MultiplayerWarmupComponent)
@@ -21,6 +30,11 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
     private readonly CrpgConstants _constants;
     private readonly MultiplayerGameNotificationsComponent _notificationsComponent;
     private readonly Func<(SpawnFrameBehaviorBase, SpawningBehaviorBase)>? _createSpawnBehaviors;
+    private MissionTimer? _rewardTickTimer;
+    private MissionTime _currentStateStartTime;
+    private List<MissionPeer> _players = new();
+    public event Action<float> OnWarmupRewardTick = default!;
+    public event Action<int> OnUpdatePlayerCount = default!;
 
     public CrpgWarmupComponent(CrpgConstants constants,
         MultiplayerGameNotificationsComponent notificationsComponent,
@@ -34,11 +48,39 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
     private WarmupStates WarmupStateReflection
     {
         get => (WarmupStates)WarmupStateField.GetValue(this)!;
-        set => WarmupStateField.SetValue(this, value);
+        set
+        {
+            WarmupStateField.SetValue(this, value);
+            if (GameNetwork.IsServer)
+            {
+                _currentStateStartTime = MissionTime.Now;
+                GameNetwork.BeginBroadcastModuleEvent();
+                GameNetwork.WriteMessage(new WarmupStateChange(WarmupStateReflection, _currentStateStartTime.NumberOfTicks));
+                GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+            }
+        } 
     }
 
     private MultiplayerTimerComponent TimerComponentReflection => (MultiplayerTimerComponent)TimerComponentField.GetValue(this)!;
     private MissionMultiplayerGameModeBase GameModeReflection => (MissionMultiplayerGameModeBase)GameModeField.GetValue(this)!;
+
+    public override void OnBehaviorInitialize()
+    {
+        base.OnBehaviorInitialize();
+        MissionPeer.OnTeamChanged += HandlePeerTeamChanged;
+    }
+
+    public override void OnRemoveBehavior()
+    {
+        base.OnRemoveBehavior();
+        MissionPeer.OnTeamChanged -= HandlePeerTeamChanged;
+    }
+
+    protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)
+    {
+        base.AddRemoveMessageHandlers(registerer);
+        registerer.Register<WarmupStateChange>(HandleServerEventWarmupStateChange);
+    }
 
     public override void OnPreDisplayMissionTick(float dt)
     {
@@ -61,8 +103,7 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
 
                 break;
             case WarmupStates.Ending:
-                if (TimerComponentReflection.CheckIfTimerPassed()
-                    && GameNetwork.NetworkPeers.Count() >= MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue())
+                if (TimerComponentReflection.CheckIfTimerPassed())
                 {
                     EndWarmup();
                 }
@@ -80,6 +121,82 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
         }
     }
 
+    public override void OnMissionTick(float dt)
+    {
+        if (!GameNetwork.IsServer)
+        {
+            return;
+        }
+
+        RewardUsers();
+    }
+    protected override void HandleNewClientAfterSynchronized(NetworkCommunicator networkPeer)
+    {
+        if (IsInWarmup && !networkPeer.IsServerPeer)
+        {
+            GameNetwork.BeginBroadcastModuleEvent();
+            GameNetwork.WriteMessage(new WarmupStateChange(WarmupStateReflection, _currentStateStartTime.NumberOfTicks));
+            GameNetwork.EndBroadcastModuleEvent(GameNetwork.EventBroadcastFlags.None);
+        }
+    }
+
+    private void HandleServerEventWarmupStateChange(WarmupStateChange message)
+    {
+        WarmupStateReflection = message.WarmupState;
+        switch (WarmupStateReflection)
+        {
+            case WarmupStates.InProgress:
+                TimerComponentReflection.StartTimerAsClient(message.StateStartTimeInSeconds, TotalWarmupDuration);
+                break;
+            case WarmupStates.Ending:
+                TimerComponentReflection.StartTimerAsClient(message.StateStartTimeInSeconds, 30f);
+                ReflectionHelper.RaiseEvent(this, nameof(OnWarmupEnding), Array.Empty<object>());
+                _notificationsComponent.WarmupEnding();
+                break;
+            case WarmupStates.Ended:
+                TimerComponentReflection.StartTimerAsClient(message.StateStartTimeInSeconds, 3f);
+                ReflectionHelper.RaiseEvent(this, nameof(OnWarmupEnded), Array.Empty<object>());
+                PlayBattleStartingSound();
+                break;
+        }
+    }
+
+    private void HandlePeerTeamChanged(NetworkCommunicator peer, Team oldTeam, Team newTeam)
+    {
+        if (GameNetwork.VirtualPlayers[peer.VirtualPlayer.Index] != peer.VirtualPlayer)
+        {
+            return;
+        }
+
+        MissionPeer component = peer.GetComponent<MissionPeer>();
+        if (newTeam == null || newTeam == Mission.SpectatorTeam)
+        {
+            _players.Remove(component);
+        }
+
+        if ((oldTeam == null || oldTeam.Side == BattleSideEnum.None) && newTeam != Mission.SpectatorTeam)
+        {
+            _players.Add(component);
+        }
+
+        UpdateRemainingPlayers();
+    }
+
+    private void UpdateRemainingPlayers()
+    {
+        // calculate number of remaining players needed to start game
+        OnUpdatePlayerCount?.Invoke(TaleWorlds.Library.MathF.Max(MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue() - _players.Count(), 0));
+    }
+
+    private void RewardUsers()
+    {
+        _rewardTickTimer ??= new MissionTimer(duration: WarmupRewardTimer);
+        if (_rewardTickTimer.Check(reset: true))
+        {
+            OnWarmupRewardTick?.Invoke(_rewardTickTimer.GetTimerDuration());
+        }
+    }
+
     private void BeginWarmup()
     {
         WarmupStateReflection = WarmupStates.InProgress;
@@ -88,7 +205,7 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
         TimerComponentReflection.StartTimerAsServer(TotalWarmupDuration);
         GameModeReflection.SpawnComponent.SpawningBehavior.Clear();
         SpawnComponent spawnComponent = Mission.GetMissionBehavior<SpawnComponent>();
-        spawnComponent.SetNewSpawnFrameBehavior(new FFASpawnFrameBehavior());
+        spawnComponent.SetNewSpawnFrameBehavior(new CrpgWarmupSpawnFrameBehavior());
         spawnComponent.SetNewSpawningBehavior(new CrpgWarmupSpawningBehavior(_constants));
     }
 
@@ -97,22 +214,18 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
         WarmupStateReflection = WarmupStates.Ending;
         TimerComponentReflection.StartTimerAsServer(30f);
         ReflectionHelper.RaiseEvent(this, nameof(OnWarmupEnding), Array.Empty<object>());
-        if (!GameNetwork.IsDedicatedServer)
-        {
-            _notificationsComponent.WarmupEnding();
-        }
     }
 
     private void EndWarmup()
     {
+        if (!Mission.GetMissionBehavior<MissionMultiplayerGameModeBase>().CheckForWarmupEnd())
+        {
+            Mission.GetMissionBehavior<MissionLobbyComponent>().SetStateEndingAsServer();
+        }
+
         WarmupStateReflection = WarmupStates.Ended;
         TimerComponentReflection.StartTimerAsServer(3f);
         ReflectionHelper.RaiseEvent(this, nameof(OnWarmupEnded), Array.Empty<object>());
-
-        if (!GameNetwork.IsDedicatedServer)
-        {
-            ReflectionHelper.InvokeMethod(this, "PlayBattleStartingSound", Array.Empty<object>());
-        }
 
         Mission.Current.ResetMission();
         GameModeReflection.MultiplayerTeamSelectComponent.BalanceTeams();
@@ -122,5 +235,21 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
         (SpawnFrameBehaviorBase spawnFrame, SpawningBehaviorBase spawning) = _createSpawnBehaviors!();
         spawnComponent.SetNewSpawnFrameBehavior(spawnFrame);
         spawnComponent.SetNewSpawningBehavior(spawning);
+    }
+
+    private void PlayBattleStartingSound()
+    {
+        MatrixFrame cameraFrame = Mission.Current.GetCameraFrame();
+        Vec3 vec = cameraFrame.origin + cameraFrame.rotation.u;
+        NetworkCommunicator myPeer = GameNetwork.MyPeer;
+        MissionPeer missionPeer = myPeer.GetComponent<MissionPeer>();
+        if (missionPeer?.Team != null)
+        {
+            string text = (missionPeer.Team.Side == BattleSideEnum.Attacker) ? MultiplayerOptions.OptionType.CultureTeam1.GetStrValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions) : MultiplayerOptions.OptionType.CultureTeam2.GetStrValue(MultiplayerOptions.MultiplayerOptionsAccessMode.CurrentMapOptions);
+            MBSoundEvent.PlaySound(SoundEvent.GetEventIdFromString("event:/alerts/rally/" + text.ToLower()), vec);
+            return;
+        }
+
+        MBSoundEvent.PlaySound(SoundEvent.GetEventIdFromString("event:/alerts/rally/generic"), vec);
     }
 }

--- a/src/Module.Server/Modes/Warmup/CrpgWarmupSpawnFrameBehavior.cs
+++ b/src/Module.Server/Modes/Warmup/CrpgWarmupSpawnFrameBehavior.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.Modes.Warmup;
+public class CrpgWarmupSpawnFrameBehavior : SpawnFrameBehaviorBase
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+    }
+
+    public override MatrixFrame GetSpawnFrame(Team team, bool hasMount, bool isInitialSpawn)
+    {
+        List<GameEntity> spawnPoints = SpawnPoints.ToList();
+
+        return GetSpawnFrameFromSpawnPoints(spawnPoints, team, hasMount);
+    }
+
+    private MatrixFrame GetSpawnFrameFromSpawnPoints(IList<GameEntity> spawnPointsList, Team team, bool hasMount)
+    {
+        float highScore = float.MinValue;
+        int index = -1;
+        for (int i = 0; i < spawnPointsList.Count; i++)
+        {
+            float score = MBRandom.RandomFloat * 2f;
+            float proximityScore = 0f;
+            if (hasMount && spawnPointsList[i].HasTag("exclude_mounted"))
+            {
+                score -= 1000f;
+            }
+
+            if (!hasMount && spawnPointsList[i].HasTag("exclude_footmen"))
+            {
+                score -= 1000f;
+            }
+
+            foreach (Agent agent in Mission.Current.Agents)
+            {
+                if (agent.IsMount)
+                {
+                    continue;
+                }
+
+                float distance = (agent.Position - spawnPointsList[i].GlobalPosition).Length;
+                float influence = 3.0f - distance * 0.15f;
+                proximityScore += influence;
+            }
+
+            if (proximityScore > 0f)
+            {
+                proximityScore /= (float)Mission.Current.Agents.Count;
+            }
+
+            score += proximityScore;
+            if (score > highScore)
+            {
+                highScore = score;
+                index = i;
+            }
+        }
+
+        MatrixFrame globalFrame = spawnPointsList[index].GetGlobalFrame();
+        globalFrame.rotation.OrthonormalizeAccordingToForwardAndKeepUpAsZAxis();
+        return globalFrame;
+    }
+}

--- a/src/Module.Server/ModuleData/Languages/CNs/std_module_strings_xml-zho-CN.xml
+++ b/src/Module.Server/ModuleData/Languages/CNs/std_module_strings_xml-zho-CN.xml
@@ -90,6 +90,8 @@
     <string id="uRmpZM0q" text="请等待 {COOLDOWN} 秒再发出新的命令！" />
     <string id="7WDWLbpV" text="你不是指挥官！" />
     <string id="l81jAS1c" text="您将在 {TIME} 秒后重生！" />
+    <string id="XJTX8w8Q" text="热身阶段 - {GAME_MODE}{newline}等待 {PLAYERS} 位玩家加入" />
+    
 
     <!-- Notifications -->
     <string id="pCIKeing" text="你将在 {SECONDS} 秒后因长时间不活动而被移除！" />

--- a/src/Module.Server/ModuleData/Languages/RU/std_module_strings_xml-rus.xml
+++ b/src/Module.Server/ModuleData/Languages/RU/std_module_strings_xml-rus.xml
@@ -90,6 +90,7 @@
     <string id="uRmpZM0q" text="Подождите {COOLDOWN} секунд для отдачи нового приказа!" />
     <string id="7WDWLbpV" text="Ты не Командир!" />
     <string id="l81jAS1c" text="Вы возродитесь через {TIME} {?PLURAL}секунд!{?}секунду!{\?}" />
+    <string id="XJTX8w8Q" text="Фаза разминки - {GAME_MODE}{newline}Ожидание подключения {PLAYERS} игрок(ов)" />
 
     <!-- Notifications -->
     <string id="pCIKeing" text="Вы будете удалены за бездействие через {SECONDS} секунд!" />

--- a/src/Module.Server/ModuleData/Languages/RU/std_module_strings_xml-rus.xml
+++ b/src/Module.Server/ModuleData/Languages/RU/std_module_strings_xml-rus.xml
@@ -90,7 +90,7 @@
     <string id="uRmpZM0q" text="Подождите {COOLDOWN} секунд для отдачи нового приказа!" />
     <string id="7WDWLbpV" text="Ты не Командир!" />
     <string id="l81jAS1c" text="Вы возродитесь через {TIME} {?PLURAL}секунд!{?}секунду!{\?}" />
-    <string id="XJTX8w8Q" text="Фаза разминки - {GAME_MODE}{newline}Ожидание подключения {PLAYERS} игрок(ов)" />
+    <string id="XJTX8w8Q" text="Фаза разминки - {GAME_MODE}{newline}Ожидание подключения {PLAYERS} игрока(ов)" />
 
     <!-- Notifications -->
     <string id="pCIKeing" text="Вы будете удалены за бездействие через {SECONDS} секунд!" />

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -73,6 +73,7 @@ internal class CrpgRewardServer : MissionLogic
         if (_warmupComponent != null)
         {
             _warmupComponent.OnWarmupEnded += OnWarmupEnded;
+            _warmupComponent.OnWarmupRewardTick += OnWarmupRewardTick;
         }
     }
 
@@ -83,6 +84,7 @@ internal class CrpgRewardServer : MissionLogic
         if (_warmupComponent != null)
         {
             _warmupComponent.OnWarmupEnded -= OnWarmupEnded;
+            _warmupComponent.OnWarmupRewardTick -= OnWarmupRewardTick;
         }
     }
 
@@ -251,7 +253,7 @@ internal class CrpgRewardServer : MissionLogic
 
         var playingPeers = networkPeers
             .Select(p => p.GetComponent<MissionPeer>())
-            .Where(mp => mp != null && mp.Team != Mission.SpectatorTeam)
+            .Where(mp => mp != null && mp.Team != null && mp.Team.Side != BattleSideEnum.None)
             .ToList();
 
         bool veryLowPopulationServer = playingPeers.Count < 2;
@@ -322,7 +324,7 @@ internal class CrpgRewardServer : MissionLogic
                 userUpdate.Statistics.Rating = GetNewRating(crpgPeer);
             }
 
-            bool isPlayerInSpectator = missionPeer.Team?.Side == BattleSideEnum.None;
+            bool isPlayerInSpectator = missionPeer.Team == null || missionPeer.Team?.Side == BattleSideEnum.None;
             if (crpgPeer.LastSpawnInfo != null && !isPlayerInSpectator)
             {
                 bool isValorousPlayer = valorousPlayerIds.Contains(playerId);
@@ -516,6 +518,11 @@ internal class CrpgRewardServer : MissionLogic
     private void OnWarmupEnded()
     {
         _ = UpdateCrpgUsersAsync(durationRewarded: 0, updateUserStats: false);
+    }
+
+    private void OnWarmupRewardTick(float durationReward)
+    {
+        _ = UpdateCrpgUsersAsync(durationRewarded: durationReward, durationUpkeep: 0, constantMultiplier: 2, updateUserStats: false);
     }
 
     private void SetRewardForConnectedPlayer(

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -337,6 +337,11 @@ internal class CrpgRewardServer : MissionLogic
 
                 // TODO should probably implement compensation for disconnected users here
             }
+            else if (crpgPeer.LastSpawnInfo != null && isPlayerInSpectator) // update spectators multiplier based on their previous team
+            {
+                SetRewardForConnectedPlayer(userUpdate, crpgPeer, 0, 0, false,
+                    defenderMultiplierGain, attackerMultiplierGain, constantMultiplier);
+            }
 
             userUpdates.Add(userUpdate);
         }


### PR DESCRIPTION
Overhauls the warmup behaviour

- Warmup gives a constant 2x multiplier (1x if solo) reward every 30 seconds.
- Warmup will only end after timer (to change map) or if gamemode specific requirements are met (after 30 seconds).
  - Battle (10) & Conquest (14) have minimum playercount requirements
  - Other modes will just need 1 player to skip warmup
 - Added players required to start indicator to UI
 - Fixed some originally missing notifications / timer updates for clients