### PR TITLE
Equipment Chest to Rearm Players in DTV

### DIFF
--- a/src/Module.Client/Module.Client.csproj
+++ b/src/Module.Client/Module.Client.csproj
@@ -52,6 +52,7 @@
     <Compile Remove="..\Module.Server\Common\NotAllPlayersReadyComponent.cs" />
     <Compile Remove="..\Module.Server\Common\MapPoolComponent.cs" />
     <Compile Remove="..\Module.Server\Common\ChatCommands\**\*" />
+    <Compile Remove="..\Module.Server\Common\EquipmentChestTimeoutBehavior.cs" />
     <Compile Remove="..\Module.Server\Rewards\CrpgRewardServer.cs" />
     <Compile Remove="..\Module.Server\Firewall\*" />
     <Compile Remove="..\Module.Server\Common\RemoveIpFromFirewallBehavior.cs" />

--- a/src/Module.Editor/Module.Editor.csproj
+++ b/src/Module.Editor/Module.Editor.csproj
@@ -56,6 +56,7 @@
     <Compile Remove="..\Module.Server\Common\NotAllPlayersReadyComponent.cs" />
     <Compile Remove="..\Module.Server\Common\MapPoolComponent.cs" />
     <Compile Remove="..\Module.Server\Common\ChatCommands\**\*" />
+    <Compile Remove="..\Module.Server\Common\EquipmentChestTimeoutBehavior.cs" />
     <Compile Remove="..\Module.Server\Rewards\CrpgRewardServer.cs" />
     <Compile Remove="..\Module.Server\Firewall\*" />
     <EmbeddedResource Remove="GUI\**" />

--- a/src/Module.Server/Common/CrpgUserManagerServer.cs
+++ b/src/Module.Server/Common/CrpgUserManagerServer.cs
@@ -34,6 +34,25 @@ internal class CrpgUserManagerServer : MissionNetwork
         _constants = constants;
         _clanTasks = new Dictionary<int, Task<CrpgResult<CrpgClan>>>();
     }
+    public async Task<CrpgUser> GetUpdatedCrpgUser(NetworkCommunicator networkPeer)
+    {
+        var crpgPeer = networkPeer.GetComponent<CrpgPeer>();
+        VirtualPlayer vp = networkPeer.VirtualPlayer;
+        string userName = vp.UserName;
+        TryConvertPlatform(vp.Id.ProvidedType, out Platform platform);
+
+
+        string platformUserId = PlayerIdToPlatformUserId(vp.Id, platform);
+
+        CrpgUser crpgUser;
+
+        var userRes = CrpgFeatureFlags.IsEnabled(CrpgFeatureFlags.FeatureTournament)
+            ? await _crpgClient.GetTournamentUserAsync(platform, platformUserId)
+            : await _crpgClient.GetUserAsync(platform, platformUserId, CrpgServerConfiguration.Region);
+        crpgUser = userRes.Data!;
+
+        return crpgUser;
+    }
 
     public override void OnPlayerDisconnectedFromServer(NetworkCommunicator networkPeer)
     {

--- a/src/Module.Server/Common/CrpgUserManagerServer.cs
+++ b/src/Module.Server/Common/CrpgUserManagerServer.cs
@@ -34,14 +34,13 @@ internal class CrpgUserManagerServer : MissionNetwork
         _constants = constants;
         _clanTasks = new Dictionary<int, Task<CrpgResult<CrpgClan>>>();
     }
+
     public async Task<CrpgUser> GetUpdatedCrpgUser(NetworkCommunicator networkPeer)
     {
         var crpgPeer = networkPeer.GetComponent<CrpgPeer>();
         VirtualPlayer vp = networkPeer.VirtualPlayer;
         string userName = vp.UserName;
         TryConvertPlatform(vp.Id.ProvidedType, out Platform platform);
-
-
         string platformUserId = PlayerIdToPlatformUserId(vp.Id, platform);
 
         CrpgUser crpgUser;

--- a/src/Module.Server/Common/EquipmentChestTimeoutBehavior.cs
+++ b/src/Module.Server/Common/EquipmentChestTimeoutBehavior.cs
@@ -1,0 +1,218 @@
+﻿using System.Linq;
+using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
+using Crpg.Module.Notifications;
+using Crpg.Module.Rewards;
+using Crpg.Module.Scripts;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.LinQuick;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.ObjectSystem;
+
+
+namespace Crpg.Module.Common;
+
+internal class EquipmentChestTimeoutBehavior : MissionBehavior
+{
+    private Dictionary<CrpgPeer, int> timeSinceLastRearmed = new Dictionary<CrpgPeer, int>();
+    private readonly CrpgRewardServer _rewardServer;
+    private int RearmTimeout = 3000;
+
+
+    public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+
+    public EquipmentChestTimeoutBehavior(CrpgRewardServer rewardServer)
+    {
+        _rewardServer = rewardServer;
+    }
+
+
+
+    public override void OnAgentBuild(Agent agent, Banner banner)
+    {
+
+
+        if (agent == null)
+        {
+            return;
+        }
+
+        if (agent.Equipment == null)
+        {
+            return;
+        }
+
+        if (!agent.IsAIControlled)
+        {
+            var networkPeer = agent.MissionPeer.GetNetworkPeer();
+
+            if (networkPeer != null)
+            {
+
+                CrpgPeer? crpgPeer = networkPeer.GetComponent<CrpgPeer>();
+                DateTime dateTime = DateTime.Now;
+
+                if (timeSinceLastRearmed.ContainsKey(crpgPeer))
+                {
+                    timeSinceLastRearmed[crpgPeer] = (int)dateTime.TimeOfDay.TotalMilliseconds;
+                }
+                else
+                {
+                    timeSinceLastRearmed.Add(crpgPeer, (int)dateTime.TimeOfDay.TotalMilliseconds);
+
+                }
+            }
+        }
+    }
+
+
+    public override void OnObjectUsed(Agent userAgent, UsableMissionObject usedObject)
+    {
+        if (usedObject.GetType() == typeof(Scripts.CrpgStandingPoint))
+        {
+            CrpgStandingPoint crpgPoint = (CrpgStandingPoint)usedObject;
+            if (crpgPoint != null)
+            {
+
+                Debug.Print(crpgPoint.getParentUsableMachine().GetType().ToString());
+
+                if (crpgPoint.getParentUsableMachine().GetType() == typeof(EquipmentChest))
+                {
+
+
+
+                    var networkPeer = userAgent.MissionPeer.GetNetworkPeer();
+
+                    if (networkPeer != null)
+                    {
+
+                        CrpgPeer? crpgPeer = networkPeer.GetComponent<CrpgPeer>();
+                        DateTime dateTime = DateTime.Now;
+                        int timeDiff = (int)dateTime.TimeOfDay.TotalMilliseconds - timeSinceLastRearmed[crpgPeer];
+
+                        if (timeDiff > RearmTimeout)
+                        {
+
+                            List<CrpgUserUpdate> userUpdates = new();
+                            Guid idempotencyKey = Guid.NewGuid();
+
+                            var request = new CrpgGameUsersUpdateRequest
+                            {
+                                Updates = userUpdates,
+                                Key = idempotencyKey.ToString(),
+                            };
+                            Debug.Print("hello");
+                            //_rewardServer.UpdateCrpgUsersAsync(durationRewarded: 0, updateUserStats: false);
+                            var task = Task.Run(async () => await _rewardServer.UpdateCrpgUsersAsync(durationRewarded: 0, updateUserStats: false));
+                            base.OnObjectUsed(userAgent, usedObject);
+                            timeSinceLastRearmed[crpgPeer] = (int)dateTime.TimeOfDay.TotalMilliseconds;
+                            float previousHealth = userAgent.Health;
+
+                            Agent? newAgent = RefreshPlayer(networkPeer);
+                            if (newAgent != null)
+                            {
+                                newAgent.Health = previousHealth;
+                            }
+                            else
+                            {
+                                Debug.Print("NULLLLLL");
+                                //Do something because this shouldnt be null lol
+                            }
+                        }
+                        else
+                        {
+
+                            Debug.Print(timeDiff.ToString());
+                            int nextAvailableRearm = RearmTimeout - timeDiff;
+
+                            GameNetwork.BeginModuleEventAsServer(networkPeer);
+                            GameNetwork.WriteMessage(new CrpgNotificationId
+                            {
+                                Type = CrpgNotificationType.Announcement,
+                                TextId = "str_notification",
+                                TextVariation = "rearm_gear_timeout",
+                                SoundEvent = string.Empty,
+                                Variables = { ["SECONDS"] = (nextAvailableRearm / 1000).ToString() },
+
+                            });
+                            GameNetwork.EndModuleEventAsServer();
+
+                            userAgent.StopUsingGameObject();
+                        }
+                    }
+                    return;
+
+                }
+            }
+        }
+    }
+
+    public Agent? RefreshPlayer(NetworkCommunicator networkPeer)
+    {
+        BasicCultureObject cultureTeam1 = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam1.GetStrValue());
+        BasicCultureObject cultureTeam2 = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
+
+        MissionPeer missionPeer = networkPeer.GetComponent<MissionPeer>();
+        CrpgPeer crpgPeer = networkPeer.GetComponent<CrpgPeer>();
+        Agent controlledAgent = missionPeer.ControlledAgent;
+
+
+        controlledAgent.ClearEquipment();
+        controlledAgent.FadeOut(true, true);
+
+        BasicCultureObject teamCulture = missionPeer.Team == Mission.AttackerTeam ? cultureTeam1 : cultureTeam2;
+        var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>("crpg_captain_division_1");
+        var characterSkills = CrpgCharacterBuilder.CreateCharacterSkills(crpgPeer.User!.Character.Characteristics);
+        var characterXml = peerClass.HeroCharacter;
+
+        var characterEquipment = CrpgCharacterBuilder.CreateCharacterEquipment(crpgPeer.User.Character.EquippedItems);
+
+        MatrixFrame spawnFrame = controlledAgent.Frame;
+        var troopOrigin = new CrpgBattleAgentOrigin(characterXml, characterSkills);
+        CrpgCharacterBuilder.AssignArmorsToTroopOrigin(troopOrigin, crpgPeer.User.Character.EquippedItems.ToList());
+        AgentBuildData agentBuildData = new AgentBuildData(characterXml)
+            .MissionPeer(missionPeer)
+            .Equipment(characterEquipment)
+            .TroopOrigin(troopOrigin)
+            .Team(missionPeer.Team)
+            .VisualsIndex(0)
+            .IsFemale(missionPeer.Peer.IsFemale)
+            .BodyProperties(characterXml.GetBodyPropertiesMin())
+            .InitialPosition(spawnFrame.origin)
+            .InitialDirection(spawnFrame.rotation.f.AsVec2);
+
+        if (crpgPeer.Clan != null)
+        {
+            agentBuildData.ClothingColor1(crpgPeer.Clan.PrimaryColor);
+            agentBuildData.ClothingColor2(crpgPeer.Clan.SecondaryColor);
+            if (!string.IsNullOrEmpty(crpgPeer.Clan.BannerKey))
+            {
+                agentBuildData.Banner(new Banner(crpgPeer.Clan.BannerKey));
+            }
+        }
+        else
+        {
+            agentBuildData.ClothingColor1(missionPeer.Team == Mission.AttackerTeam
+                ? teamCulture.Color
+                : teamCulture.ClothAlternativeColor);
+            agentBuildData.ClothingColor2(missionPeer.Team == Mission.AttackerTeam
+                ? teamCulture.Color2
+                : teamCulture.ClothAlternativeColor2);
+        }
+
+        Agent agent = Mission.SpawnAgent(agentBuildData);
+        CrpgAgentComponent agentComponent = new(agent);
+        agent.AddComponent(agentComponent);
+
+        bool hasExtraSlotEquipped = characterEquipment[EquipmentIndex.ExtraWeaponSlot].Item != null;
+        if (!agent.HasMount || hasExtraSlotEquipped)
+        {
+            agent.WieldInitialWeapons();
+        }
+        Debug.Print("DONE");
+        return agent;
+    }
+
+
+}

--- a/src/Module.Server/Common/EquipmentChestTimeoutBehavior.cs
+++ b/src/Module.Server/Common/EquipmentChestTimeoutBehavior.cs
@@ -193,6 +193,14 @@ internal class EquipmentChestTimeoutBehavior : MissionBehavior
             agent.WieldInitialWeapons();
         }
 
+
+        if (agent.MissionPeer.ControlledFormation != null)
+        {
+            agent.Team.AssignPlayerAsSergeantOfFormation(agent.MissionPeer, agent.MissionPeer.ControlledFormation.FormationIndex);
+        }
+
+        crpgPeer.LastSpawnInfo = new SpawnInfo(agent.MissionPeer.Team, updatedUser.Character.EquippedItems);
+
         return agent;
     }
 }

--- a/src/Module.Server/Common/EquipmentChestTimeoutBehavior.cs
+++ b/src/Module.Server/Common/EquipmentChestTimeoutBehavior.cs
@@ -1,46 +1,27 @@
-﻿using System.Globalization;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Xml.Linq;
-using Crpg.Module.Api;
-using Crpg.Module.Api.Models;
-using Crpg.Module.Api.Models.Characters;
-using Crpg.Module.Api.Models.Users;
-using Crpg.Module.Common.ChatCommands;
-using Crpg.Module.Common.Commander;
+﻿using Crpg.Module.Api.Models.Users;
 using Crpg.Module.Modes.Dtv;
-using Crpg.Module.Notifications;
-using Crpg.Module.Rating;
-using Crpg.Module.Rewards;
 using Crpg.Module.Scripts;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using TaleWorlds.LinQuick;
 using TaleWorlds.MountAndBlade;
-using TaleWorlds.MountAndBlade.Diamond;
-using TaleWorlds.ObjectSystem;
-using TaleWorlds.PlayerServices;
-using Platform = Crpg.Module.Api.Models.Users.Platform;
-
 
 namespace Crpg.Module.Common;
 
 internal class EquipmentChestTimeoutBehavior : MissionBehavior
 {
-
     public event Action<CrpgPeer> OnEquipChestUsed = default!;
-
-    private Dictionary<CrpgPeer, int> timeSinceLastRearmed = new Dictionary<CrpgPeer, int>();
-    private readonly CrpgRewardServer _rewardServer;
-    private readonly ICrpgClient _crpgClient;
-    private float RearmTimeout = 3000; // Time between equipment chest uses in ms
     public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+    public Dictionary<int, float> TimeSinceLastRearmed = new Dictionary<int, float>();
+
+    public MissionTime CurrentRoundStartTime;
+
+    private readonly CrpgSpawningBehaviorBase _spawnBehavior;
+    private readonly float rearmTimeout = 3000; // Time between equipment chest uses in ms
     private CrpgUserManagerServer? _crpgUserManager;
 
-    public EquipmentChestTimeoutBehavior(CrpgRewardServer rewardServer, ICrpgClient crpgClient)
+    public EquipmentChestTimeoutBehavior(CrpgSpawningBehaviorBase spawnBehavior)
     {
-        _rewardServer = rewardServer;
-        _crpgClient = crpgClient;
+        _spawnBehavior = spawnBehavior;
     }
 
     public override void OnAgentBuild(Agent agent, Banner banner)
@@ -54,28 +35,6 @@ internal class EquipmentChestTimeoutBehavior : MissionBehavior
         {
             return;
         }
-
-        if (!agent.IsAIControlled)
-        {
-            var networkPeer = agent.MissionPeer.GetNetworkPeer();
-
-            if (networkPeer != null)
-            {
-
-                CrpgPeer? crpgPeer = networkPeer.GetComponent<CrpgPeer>();
-                DateTime dateTime = DateTime.Now;
-
-                if (timeSinceLastRearmed.ContainsKey(crpgPeer))
-                {
-                    timeSinceLastRearmed[crpgPeer] = (int)dateTime.TimeOfDay.TotalMilliseconds;
-                }
-                else
-                {
-                    timeSinceLastRearmed.Add(crpgPeer, (int)dateTime.TimeOfDay.TotalMilliseconds);
-
-                }
-            }
-        }
     }
 
     public override async void OnObjectUsed(Agent userAgent, UsableMissionObject usedObject)
@@ -85,122 +44,60 @@ internal class EquipmentChestTimeoutBehavior : MissionBehavior
             CrpgStandingPoint crpgPoint = (CrpgStandingPoint)usedObject;
             if (crpgPoint != null)
             {
-                if (crpgPoint.getParentUsableMachine().GetType() == typeof(EquipmentChest))
+                if (crpgPoint.parentUsableMachine != null)
                 {
-                    var networkPeer = userAgent.MissionPeer.GetNetworkPeer();
-
-                    if (networkPeer != null)
+                    if (crpgPoint.parentUsableMachine.GetType() == typeof(EquipmentChest))
                     {
-                        CrpgPeer? crpgPeer = networkPeer.GetComponent<CrpgPeer>();
-                        DateTime dateTime = DateTime.Now;
-                        float timeDiff = (float)dateTime.TimeOfDay.TotalMilliseconds - timeSinceLastRearmed[crpgPeer];
+                        var networkPeer = userAgent.MissionPeer.GetNetworkPeer();
 
-                        if (timeDiff > RearmTimeout)
+                        if (networkPeer != null)
                         {
-                            base.OnObjectUsed(userAgent, usedObject);
-                            OnEquipChestUsed?.Invoke(crpgPeer);
+                            CrpgPeer? crpgPeer = networkPeer.GetComponent<CrpgPeer>();
 
-                            _crpgUserManager = Mission.GetMissionBehavior<CrpgUserManagerServer>();
-                            CrpgUser crpgUser = await _crpgUserManager.GetUpdatedCrpgUser(networkPeer);
-
-                            timeSinceLastRearmed[crpgPeer] = (int)dateTime.TimeOfDay.TotalMilliseconds;
-                            float previousHealth = userAgent.Health;
-
-
-
-                            Agent? newAgent = RefreshPlayer(networkPeer, crpgUser);
-                            if (newAgent != null)
+                            if (crpgPeer.User != null)
                             {
-                                newAgent.Health = previousHealth;
+                                int userId = crpgPeer.User.Id;
+                                if (!TimeSinceLastRearmed.TryGetValue(userId, out float lastUsedChest))
+                                {
+                                    lastUsedChest = 0;
+                                }
+
+                                float timeDiff = CurrentRoundStartTime.ElapsedMilliseconds - lastUsedChest;
+                                if (timeDiff > rearmTimeout)
+                                {
+                                    base.OnObjectUsed(userAgent, usedObject);
+                                    OnEquipChestUsed?.Invoke(crpgPeer);
+
+                                    _crpgUserManager = Mission.GetMissionBehavior<CrpgUserManagerServer>();
+                                    CrpgUser crpgUser = await _crpgUserManager.GetUpdatedCrpgUser(networkPeer);
+
+                                    TimeSinceLastRearmed[userId] = CurrentRoundStartTime.ElapsedMilliseconds;
+                                    Debug.Print("AHHHH");
+                                    Debug.Print(CurrentRoundStartTime.ElapsedMilliseconds.ToString());
+                                    float previousHealth = userAgent.Health;
+
+                                    Agent? newAgent = _spawnBehavior.RefreshPlayerWithNewLoadout(networkPeer, crpgUser);
+                                    if (newAgent != null)
+                                    {
+                                        newAgent.Health = previousHealth;
+                                    }
+                                }
+                                else
+                                {
+                                    float timeoutDuration = rearmTimeout - timeDiff;
+                                    GameNetwork.BeginModuleEventAsServer(networkPeer);
+                                    GameNetwork.WriteMessage(new CrpgDtvEquipChestTimeoutMessage { TimeoutDuration = (float)timeoutDuration });
+                                    GameNetwork.EndModuleEventAsServer();
+                                    userAgent.StopUsingGameObject();
+                                }
                             }
                         }
-                        else
-                        {
-                            float timeoutDuration = RearmTimeout - timeDiff;
-                            GameNetwork.BeginModuleEventAsServer(networkPeer);
-                            GameNetwork.WriteMessage(new CrpgDtvEquipChestTimeoutMessage { TimeoutDuration = (float)timeoutDuration });
-                            GameNetwork.EndModuleEventAsServer();
-                            userAgent.StopUsingGameObject();
-                        }
-                    }
 
-                    return;
+                        return;
+                    }
                 }
             }
         }
     }
 
-    public Agent? RefreshPlayer(NetworkCommunicator networkPeer, CrpgUser updatedUser)
-    {
-        BasicCultureObject cultureTeam1 = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam1.GetStrValue());
-        BasicCultureObject cultureTeam2 = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
-
-        MissionPeer missionPeer = networkPeer.GetComponent<MissionPeer>();
-        CrpgPeer crpgPeer = networkPeer.GetComponent<CrpgPeer>();
-        Agent controlledAgent = missionPeer.ControlledAgent;
-
-
-        controlledAgent.ClearEquipment();
-        controlledAgent.FadeOut(true, true);
-
-        BasicCultureObject teamCulture = missionPeer.Team == Mission.AttackerTeam ? cultureTeam1 : cultureTeam2;
-        var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>("crpg_captain_division_1");
-        var characterSkills = CrpgCharacterBuilder.CreateCharacterSkills(updatedUser!.Character.Characteristics);
-        var characterXml = peerClass.HeroCharacter;
-
-        var characterEquipment = CrpgCharacterBuilder.CreateCharacterEquipment(updatedUser.Character.EquippedItems);
-
-        MatrixFrame spawnFrame = controlledAgent.Frame;
-        var troopOrigin = new CrpgBattleAgentOrigin(characterXml, characterSkills);
-        CrpgCharacterBuilder.AssignArmorsToTroopOrigin(troopOrigin, updatedUser.Character.EquippedItems.ToList());
-        AgentBuildData agentBuildData = new AgentBuildData(characterXml)
-            .MissionPeer(missionPeer)
-            .Equipment(characterEquipment)
-            .TroopOrigin(troopOrigin)
-            .Team(missionPeer.Team)
-            .VisualsIndex(0)
-            .IsFemale(missionPeer.Peer.IsFemale)
-            .BodyProperties(characterXml.GetBodyPropertiesMin())
-            .InitialPosition(spawnFrame.origin)
-            .InitialDirection(spawnFrame.rotation.f.AsVec2);
-
-        if (crpgPeer.Clan != null)
-        {
-            agentBuildData.ClothingColor1(crpgPeer.Clan.PrimaryColor);
-            agentBuildData.ClothingColor2(crpgPeer.Clan.SecondaryColor);
-            if (!string.IsNullOrEmpty(crpgPeer.Clan.BannerKey))
-            {
-                agentBuildData.Banner(new Banner(crpgPeer.Clan.BannerKey));
-            }
-        }
-        else
-        {
-            agentBuildData.ClothingColor1(missionPeer.Team == Mission.AttackerTeam
-                ? teamCulture.Color
-                : teamCulture.ClothAlternativeColor);
-            agentBuildData.ClothingColor2(missionPeer.Team == Mission.AttackerTeam
-                ? teamCulture.Color2
-                : teamCulture.ClothAlternativeColor2);
-        }
-
-        Agent agent = Mission.SpawnAgent(agentBuildData);
-        CrpgAgentComponent agentComponent = new(agent);
-        agent.AddComponent(agentComponent);
-
-        bool hasExtraSlotEquipped = characterEquipment[EquipmentIndex.ExtraWeaponSlot].Item != null;
-        if (!agent.HasMount || hasExtraSlotEquipped)
-        {
-            agent.WieldInitialWeapons();
-        }
-
-
-        if (agent.MissionPeer.ControlledFormation != null)
-        {
-            agent.Team.AssignPlayerAsSergeantOfFormation(agent.MissionPeer, agent.MissionPeer.ControlledFormation.FormationIndex);
-        }
-
-        crpgPeer.LastSpawnInfo = new SpawnInfo(agent.MissionPeer.Team, updatedUser.Character.EquippedItems);
-
-        return agent;
-    }
 }

--- a/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
@@ -1,4 +1,4 @@
-﻿ServerName cRPG - Test DTV - c-rpg.eu
+﻿ServerName cRPG - Test DTV3 - c-rpg.eu
 GameType cRPGDTV
 GamePassword yoyo
 AllowPollsToKickPlayers True

--- a/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
@@ -1,4 +1,4 @@
-﻿ServerName cRPG - Test DTV1 - c-rpg.eu
+﻿ServerName cRPG - Test DTV2 - c-rpg.eu
 GameType cRPGDTV
 GamePassword yoyo
 AllowPollsToKickPlayers True

--- a/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
@@ -1,4 +1,4 @@
-﻿ServerName cRPG - Test DTV3 - c-rpg.eu
+﻿ServerName cRPG - Test DTV1 - c-rpg.eu
 GameType cRPGDTV
 GamePassword yoyo
 AllowPollsToKickPlayers True

--- a/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
@@ -1,4 +1,4 @@
-﻿ServerName cRPG - Test DTV3 - c-rpg.eu
+﻿ServerName cRPG - Test DTV2 - c-rpg.eu
 GameType cRPGDTV
 GamePassword yoyo
 AllowPollsToKickPlayers True

--- a/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_dtv.txt
@@ -1,4 +1,4 @@
-﻿ServerName cRPG - Test DTV2 - c-rpg.eu
+﻿ServerName cRPG - Test DTV3 - c-rpg.eu
 GameType cRPGDTV
 GamePassword yoyo
 AllowPollsToKickPlayers True

--- a/src/Module.Server/MapRotation/ds_config_crpg_dtv_maps.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_dtv_maps.txt
@@ -1,7 +1,2 @@
-﻿crpg_dtv_qalat
-crpg_dtv_encampment
-crpg_dtv_weepinghill
-crpg_dtv_rosethornecastle
-crpg_dtv_ruinsofrahiz
-crpg_dtv_musapoint
-crpg_dtv_templeofposeidon
+﻿﻿scn_doodoo_new_chest
+scn_doodoo_new_chest

--- a/src/Module.Server/Modes/Dtv/CrpgDtvClient.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvClient.cs
@@ -70,6 +70,8 @@ internal class CrpgDtvClient : MissionMultiplayerGameModeBaseClient
         registerer.Register<CrpgDtvCurrentProgressMessage>(HandleCurrentProgress);
         registerer.Register<SetStonePileAmmo>(HandleServerEventSetStonePileAmmo);
         registerer.Register<SetRangedSiegeWeaponAmmo>(HandleServerSetRangedSiegeWeaponAmmo);
+        registerer.Register<CrpgDtvEquipChestTimeoutMessage>(HandleEquipChestTimeout);
+
     }
 
     private void HandleSetTimer(CrpgDtvSetTimerMessage message)
@@ -175,4 +177,17 @@ internal class CrpgDtvClient : MissionMultiplayerGameModeBaseClient
             rangedSiegeWeapon?.Activate();
         }
     }
+
+    private void HandleEquipChestTimeout(CrpgDtvEquipChestTimeoutMessage message)
+    {
+        float timeout = message.TimeoutDuration;
+        TextObject textObject = new("{=mfD3LkeB} Equipment chest is on cooldown for " + Math.Round(timeout / 1000, 1).ToString() + " seconds.");
+        InformationManager.DisplayMessage(new InformationMessage
+        {
+            Information = textObject.ToString(),
+            Color = new Color(0.90f, 0.25f, 0.25f),
+            SoundEventPath = "event:/ui/notification/alert",
+        });
+    }
+
 }

--- a/src/Module.Server/Modes/Dtv/CrpgDtvEquipChestTimeoutMessage.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvEquipChestTimeoutMessage.cs
@@ -1,0 +1,33 @@
+﻿using System.Text;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Crpg.Module.Modes.Dtv;
+
+[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+internal sealed class CrpgDtvEquipChestTimeoutMessage : GameNetworkMessage
+{
+    public float TimeoutDuration { get; set; }
+
+    protected override void OnWrite()
+    {
+        WriteFloatToPacket(TimeoutDuration, CompressionInfo.Float.FullPrecision);
+    }
+
+    protected override bool OnRead()
+    {
+        bool bufferReadValid = true;
+        TimeoutDuration = ReadFloatFromPacket(CompressionInfo.Float.FullPrecision, ref bufferReadValid);
+        return bufferReadValid;
+    }
+
+    protected override MultiplayerMessageFilter OnGetLogFilter()
+    {
+        return MultiplayerMessageFilter.GameMode;
+    }
+
+    protected override string OnGetLogFormat()
+    {
+        return "cRPG DTV Equipment Chest Timeout";
+    }
+}

--- a/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
@@ -149,6 +149,8 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
                 new DrowningBehavior(),
                 new PopulationBasedEntityVisibilityBehavior(lobbyComponent),
                 new CrpgCommanderBehaviorServer(),
+                new EquipmentChestTimeoutBehavior(rewardServer),
+
 #else
                 new MultiplayerAchievementComponent(),
                 MissionMatchHistoryComponent.CreateIfConditionsAreMet(),

--- a/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
@@ -149,7 +149,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
                 new DrowningBehavior(),
                 new PopulationBasedEntityVisibilityBehavior(lobbyComponent),
                 new CrpgCommanderBehaviorServer(),
-                new EquipmentChestTimeoutBehavior(rewardServer),
+                new EquipmentChestTimeoutBehavior(rewardServer, crpgClient),
 
 #else
                 new MultiplayerAchievementComponent(),

--- a/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
@@ -149,7 +149,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
                 new DrowningBehavior(),
                 new PopulationBasedEntityVisibilityBehavior(lobbyComponent),
                 new CrpgCommanderBehaviorServer(),
-                new EquipmentChestTimeoutBehavior(rewardServer, crpgClient),
+                new EquipmentChestTimeoutBehavior(spawnBehaviour),
 
 #else
                 new MultiplayerAchievementComponent(),

--- a/src/Module.Server/ModuleData/multiplayer_strings.xml
+++ b/src/Module.Server/ModuleData/multiplayer_strings.xml
@@ -67,6 +67,8 @@
   <string id="str_notification.conquest_overtime" text="{=joWaOGco}The time limit was reached but some attackers are still around the flags. Defenders will need to wipe them to win the game." />
   <string id="str_notification.entities_removed" text="{=I5MWE5AR}{ENTITY_COUNT} entities were removed from the map given the population size." />
   <string id="str_notification.moved_to_spectator" text="{=iN5cT1v3}You have been moved to spectator due to inactivity!" />
+  <string id="str_notification.rearm_gear_warning" text="{=pCIKein2}You should have at least one melee or throwing weapon equipped to rearm!" />
+  <string id="str_notification.rearm_gear_timeout" text="{=pCIKefn2}Next rearm available in {SECONDS} seconds!" />
   
   <!-- Battle Maps -->
   <string id="str_multiplayer_scene_name.crpg_battle_abandoned" text="{=PKVPlAeE}Abandoned" />

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -413,7 +413,7 @@ internal class CrpgRewardServer : MissionLogic
             {
                 if (timeSinceEquipChestUsed.TryGetValue(crpgPeer.User.Id, out float lastUsedChest))
                 {
-                    duration = duration - lastUsedChest;
+                    duration = duration - (lastUsedChest / 1000);
                 }
             }
 

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -242,7 +242,8 @@ internal class CrpgRewardServer : MissionLogic
         int? constantMultiplier = null,
         bool updateUserStats = true,
         bool isDuel = false,
-        NetworkCommunicator? singleUser = null)
+        NetworkCommunicator? singleUser = null,
+        Dictionary<int, float>? timeSinceEquipChestUsed = null)
     {
 
         NetworkCommunicator[] networkPeers = Array.Empty<NetworkCommunicator>();
@@ -396,7 +397,7 @@ internal class CrpgRewardServer : MissionLogic
         }
     }
 
-    private Dictionary<int, IList<CrpgUserDamagedItem>> GetBrokenItemsByCrpgUserId(NetworkCommunicator[] networkPeers, float duration)
+    private Dictionary<int, IList<CrpgUserDamagedItem>> GetBrokenItemsByCrpgUserId(NetworkCommunicator[] networkPeers, float duration, Dictionary<int, float>? timeSinceEquipChestUsed = null)
     {
         Dictionary<int, IList<CrpgUserDamagedItem>> brokenItems = new();
         foreach (NetworkCommunicator networkPeer in networkPeers)
@@ -406,6 +407,14 @@ internal class CrpgRewardServer : MissionLogic
             if (missionPeer == null || crpgPeer?.User == null)
             {
                 continue;
+            }
+
+            if (timeSinceEquipChestUsed != null)
+            {
+                if (timeSinceEquipChestUsed.TryGetValue(crpgPeer.User.Id, out float lastUsedChest))
+                {
+                    duration = duration - lastUsedChest;
+                }
             }
 
             if (crpgPeer.LastSpawnInfo != null)
@@ -659,6 +668,8 @@ internal class CrpgRewardServer : MissionLogic
         List<CrpgUserDamagedItem> brokenItems = new();
         foreach (var equippedItem in crpgPeer.LastSpawnInfo!.EquippedItems)
         {
+            Debug.Print(equippedItem.UserItem.ItemId.ToString());
+
             var mbItem = Game.Current.ObjectManager.GetObject<ItemObject>(equippedItem.UserItem.ItemId);
             if (_random.NextDouble() >= _constants.ItemBreakChance)
             {

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -241,9 +241,21 @@ internal class CrpgRewardServer : MissionLogic
         BattleSideEnum? valourTeamSide = null,
         int? constantMultiplier = null,
         bool updateUserStats = true,
-        bool isDuel = false)
+        bool isDuel = false,
+        NetworkCommunicator? singleUser = null)
     {
-        var networkPeers = GameNetwork.NetworkPeers.ToArray();
+
+        NetworkCommunicator[] networkPeers = Array.Empty<NetworkCommunicator>();
+        if (singleUser == null)
+        {
+            networkPeers = GameNetwork.NetworkPeers.ToArray();
+        }
+        else
+        {
+            networkPeers = new NetworkCommunicator[] { singleUser };
+        }
+
+
         if (networkPeers.Length == 0)
         {
             return;
@@ -377,7 +389,6 @@ internal class CrpgRewardServer : MissionLogic
             Debug.Print($"Couldn't update users - {e}");
 
             SendErrorToPeers(crpgPeerByCrpgUserId);
-
         }
         finally
         {
@@ -731,6 +742,7 @@ internal class CrpgRewardServer : MissionLogic
                 BrokeItemIds = updateResult.RepairedItems.Where(r => r.Broke).Select(r => r.ItemId).ToList(),
             });
             GameNetwork.EndModuleEventAsServer();
+            Debug.Print("Rewarded users");
         }
     }
 
@@ -781,4 +793,5 @@ internal class CrpgRewardServer : MissionLogic
         })
         .Build();
     }
+
 }

--- a/src/Module.Server/Scripts/CrpgStandingPoint.cs
+++ b/src/Module.Server/Scripts/CrpgStandingPoint.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.Scripts
+{
+    // Token: 0x02000021 RID: 33
+    internal class CrpgStandingPoint : StandingPoint
+    {
+
+        public UsableMachine? parentUsableMachine;
+
+        // Token: 0x06000289 RID: 649 RVA: 0x0000D6A7 File Offset: 0x0000B8A7
+        protected override void OnInit()
+        {
+            base.OnInit();
+        }
+
+        public UsableMachine? getParentUsableMachine()
+        {
+            return this.parentUsableMachine;
+        }
+
+        public void setParentUsableMachine(UsableMachine attachedUsableMachine)
+        {
+            this.parentUsableMachine = attachedUsableMachine;
+        }
+
+
+        // Token: 0x0600028A RID: 650 RVA: 0x0000D6B1 File Offset: 0x0000B8B1
+    }
+}

--- a/src/Module.Server/Scripts/EquipmentChest.cs
+++ b/src/Module.Server/Scripts/EquipmentChest.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using Crpg.Module.Api;
+using Crpg.Module.Api.Models.Items;
+using Crpg.Module.Api.Models.Users;
+using Crpg.Module.Common;
+using Crpg.Module.Modes.Dtv;
+using Crpg.Module.Modes.TrainingGround;
+using Crpg.Module.Notifications;
+using Crpg.Module.Scripts;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.InputSystem;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.ObjectSystem;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Crpg.Module.Scripts
+{
+    // Token: 0x0200035A RID: 858
+
+
+    public class EquipmentChest : UsableMachine
+    {
+        //private readonly ICrpgClient _crpgClient;
+
+        // Token: 0x170008B1 RID: 2225
+        // (get) Token: 0x06002F1A RID: 12058 RVA: 0x000C0E87 File Offset: 0x000BF087
+        private static int _pickupArrowSoundFromBarrelCache
+        {
+            get
+            {
+                if (EquipmentChest._pickupArrowSoundFromBarrel == -1)
+                {
+                    EquipmentChest._pickupArrowSoundFromBarrel = SoundEvent.GetEventIdFromString("event:/mission/combat/pickup_arrows");
+                }
+                return EquipmentChest._pickupArrowSoundFromBarrel;
+            }
+        }
+
+        // Token: 0x06002F1B RID: 12059 RVA: 0x000C0EA5 File Offset: 0x000BF0A5
+        protected EquipmentChest()
+        {
+        }
+
+        // Token: 0x06002F1C RID: 12060 RVA: 0x000C0EB4 File Offset: 0x000BF0B4
+        protected override void OnInit()
+        {
+            Debug.Print($"HELLO INIT");
+
+            base.OnInit();
+            foreach (CrpgStandingPoint standingPoint in StandingPoints)
+            {
+
+                standingPoint.setParentUsableMachine(this);
+
+            }
+            base.SetScriptComponentToTick(this.GetTickRequirement());
+            this.MakeVisibilityCheck = false;
+            this._isVisible = base.GameEntity.IsVisibleIncludeParents();
+        }
+
+
+
+        private void ServerTick(float dt)
+        {
+
+            if (!IsDeactivated)
+            {
+
+                foreach (CrpgStandingPoint standingPoint in StandingPoints)
+                {
+
+                    if (standingPoint.HasUser)
+                    {
+                        Agent userAgent = standingPoint.UserAgent;
+
+
+                    }
+
+                }
+            }
+        }
+
+        // Token: 0x06002F1E RID: 12062 RVA: 0x000C0F94 File Offset: 0x000BF194
+        public override TextObject GetActionTextForStandingPoint(UsableMissionObject usableGameObject)
+        {
+            TextObject textObject = new TextObject("{=bNYm3K6bf}{KEY} Rearm", null);
+            textObject.SetTextVariable("KEY", HyperlinkTexts.GetKeyHyperlinkText(HotKeyManager.GetHotKeyId("CombatHotKeyCategory", 13)));
+            return textObject;
+        }
+
+
+        // Token: 0x06002F1F RID: 12063 RVA: 0x000C0FBE File Offset: 0x000BF1BE
+        public override string GetDescriptionText(GameEntity? gameEntity = null)
+        {
+            return new TextObject("{=bWi4aMOB}Equipment Chest", null).ToString();
+        }
+
+        // Token: 0x06002F20 RID: 12064 RVA: 0x000C0FD0 File Offset: 0x000BF1D0
+        public override ScriptComponentBehavior.TickRequirement GetTickRequirement()
+        {
+            if (GameNetwork.IsClientOrReplay)
+            {
+                return base.GetTickRequirement();
+            }
+            return ScriptComponentBehavior.TickRequirement.Tick | ScriptComponentBehavior.TickRequirement.TickParallel | base.GetTickRequirement();
+        }
+
+        // Token: 0x06002F21 RID: 12065 RVA: 0x000C0FE8 File Offset: 0x000BF1E8
+        protected override void OnTickParallel(float dt)
+        {
+            this.TickAux(true);
+        }
+
+        // Token: 0x06002F22 RID: 12066 RVA: 0x000C0FF1 File Offset: 0x000BF1F1
+        protected override void OnTick(float dt)
+        {
+            base.OnTick(dt);
+            ServerTick(dt);
+            if (this._needsSingleThreadTickOnce)
+            {
+                this._needsSingleThreadTickOnce = false;
+                this.TickAux(false);
+            }
+        }
+
+        // Token: 0x06002F23 RID: 12067 RVA: 0x000C1010 File Offset: 0x000BF210
+        private void TickAux(bool isParallel)
+        {
+
+
+            if (this._isVisible && !GameNetwork.IsClientOrReplay)
+            {
+                foreach (CrpgStandingPoint standingPoint in base.StandingPoints)
+                {
+                    if (standingPoint.HasUser)
+                    {
+
+                        Agent userAgent = standingPoint.UserAgent;
+
+                        ActionIndexValueCache currentActionValue = userAgent.GetCurrentActionValue(0);
+                        ActionIndexValueCache currentActionValue2 = userAgent.GetCurrentActionValue(1);
+                        if (!(currentActionValue2 == ActionIndexValueCache.act_none) || (!(currentActionValue == EquipmentChest.act_pickup_down_begin) && !(currentActionValue == EquipmentChest.act_pickup_down_begin_left_stance)))
+                        {
+                            if (currentActionValue2 == ActionIndexValueCache.act_none && (currentActionValue == EquipmentChest.act_pickup_down_end || currentActionValue == EquipmentChest.act_pickup_down_end_left_stance))
+                            {
+                                if (isParallel)
+                                {
+                                    this._needsSingleThreadTickOnce = true;
+                                }
+                                else
+                                {
+
+                                    foreach (NetworkCommunicator networkPeer in GameNetwork.NetworkPeers)
+                                    {
+                                        var crpgPeer = networkPeer.GetComponent<CrpgPeer>();
+                                        MissionPeer missionPeer = networkPeer.GetComponent<MissionPeer>();
+                                        if (crpgPeer != null)
+                                        {
+                                            if (crpgPeer.User != null)
+                                            {
+                                                //var characterEquipment = CrpgCharacterBuilder.CreateCharacterEquipment(crpgPeer.User.Character.EquippedItems);
+
+                                                /*
+                                                BasicCultureObject cultureTeam1 = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam1.GetStrValue());
+                                                BasicCultureObject cultureTeam2 = MBObjectManager.Instance.GetObject<BasicCultureObject>(MultiplayerOptions.OptionType.CultureTeam2.GetStrValue());
+
+
+                                                Agent controlledAgent = missionPeer.ControlledAgent;
+
+                                                controlledAgent.ClearEquipment();
+                                                controlledAgent.FadeOut(true, true);
+
+                                                BasicCultureObject teamCulture = missionPeer.Team == userAgent.Mission.AttackerTeam ? cultureTeam1 : cultureTeam2;
+                                                var peerClass = MBObjectManager.Instance.GetObject<MultiplayerClassDivisions.MPHeroClass>("crpg_captain_division_1");
+                                                var characterSkills = CrpgCharacterBuilder.CreateCharacterSkills(crpgPeer.User!.Character.Characteristics);
+                                                var characterXml = peerClass.HeroCharacter;
+
+
+                                                MatrixFrame spawnFrame = controlledAgent.Frame;
+                                                var troopOrigin = new CrpgBattleAgentOrigin(characterXml, characterSkills);
+                                                CrpgCharacterBuilder.AssignArmorsToTroopOrigin(troopOrigin, crpgPeer.User.Character.EquippedItems.ToList());
+
+                                                AgentBuildData agentBuildData = new AgentBuildData(characterXml)
+                                                    .MissionPeer(missionPeer)
+                                                    .Equipment(characterEquipment)
+                                                    .TroopOrigin(troopOrigin)
+                                                    .Team(missionPeer.Team)
+                                                    .VisualsIndex(0)
+                                                    .IsFemale(missionPeer.Peer.IsFemale)
+                                                    .BodyProperties(characterXml.GetBodyPropertiesMin())
+                                                    .InitialPosition(spawnFrame.origin)
+                                                    .InitialDirection(spawnFrame.rotation.f.AsVec2);
+                                                if (crpgPeer.Clan != null)
+                                                {
+                                                    agentBuildData.ClothingColor1(crpgPeer.Clan.PrimaryColor);
+                                                    agentBuildData.ClothingColor2(crpgPeer.Clan.SecondaryColor);
+                                                    if (!string.IsNullOrEmpty(crpgPeer.Clan.BannerKey))
+                                                    {
+                                                        agentBuildData.Banner(new Banner(crpgPeer.Clan.BannerKey));
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    agentBuildData.ClothingColor1(missionPeer.Team == userAgent.Mission.AttackerTeam
+                                                        ? teamCulture.Color
+                                                        : teamCulture.ClothAlternativeColor);
+                                                    agentBuildData.ClothingColor2(missionPeer.Team == userAgent.Mission.AttackerTeam
+                                                        ? teamCulture.Color2
+                                                        : teamCulture.ClothAlternativeColor2);
+                                                }
+
+                                                Agent agent = userAgent.Mission.SpawnAgent(agentBuildData);
+                                                CrpgAgentComponent agentComponent = new(agent);
+                                                agent.AddComponent(agentComponent);
+
+                                                bool hasExtraSlotEquipped = characterEquipment[EquipmentIndex.ExtraWeaponSlot].Item != null;
+                                                if (!agent.HasMount || hasExtraSlotEquipped)
+                                                {
+                                                    agent.WieldInitialWeapons();
+                                                }
+                                                */
+
+                                            }
+                                        }
+
+                                    }
+
+                                    userAgent.StopUsingGameObject(true, Agent.StopUsingGameObjectFlags.AutoAttachAfterStoppingUsingGameObject);
+                                }
+                            }
+                            else if (currentActionValue2 != ActionIndexValueCache.act_none || !userAgent.SetActionChannel(0, userAgent.GetIsLeftStance() ? EquipmentChest.act_pickup_down_begin_left_stance : EquipmentChest.act_pickup_down_begin, false, 0UL, 0f, 1f, -0.2f, 0.4f, 0f, false, -0.2f, 0, true))
+                            {
+                                if (isParallel)
+                                {
+                                    this._needsSingleThreadTickOnce = true;
+                                }
+                                else
+                                {
+                                    userAgent.StopUsingGameObject(true, Agent.StopUsingGameObjectFlags.AutoAttachAfterStoppingUsingGameObject);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Token: 0x06002F24 RID: 12068 RVA: 0x000C1258 File Offset: 0x000BF458
+        public override OrderType GetOrder(BattleSideEnum side)
+        {
+            return OrderType.None;
+        }
+
+        // Token: 0x040013E2 RID: 5090
+        private static readonly ActionIndexCache act_pickup_down_begin = ActionIndexCache.Create("act_pickup_down_begin");
+
+        // Token: 0x040013E3 RID: 5091
+        private static readonly ActionIndexCache act_pickup_down_begin_left_stance = ActionIndexCache.Create("act_pickup_down_begin_left_stance");
+
+        // Token: 0x040013E4 RID: 5092
+        private static readonly ActionIndexCache act_pickup_down_end = ActionIndexCache.Create("act_pickup_down_end");
+
+        // Token: 0x040013E5 RID: 5093
+        private static readonly ActionIndexCache act_pickup_down_end_left_stance = ActionIndexCache.Create("act_pickup_down_end_left_stance");
+
+        // Token: 0x040013E6 RID: 5094
+        private static int _pickupArrowSoundFromBarrel = -1;
+
+        // Token: 0x040013E7 RID: 5095
+        private bool _isVisible = true;
+
+        // Token: 0x040013E8 RID: 5096
+        private bool _needsSingleThreadTickOnce;
+
+        private Dictionary<CrpgPeer, int> timeSinceLastRearmed = new Dictionary<CrpgPeer, int>();
+
+    }
+}


### PR DESCRIPTION
So players can change gear.

Upkeep should be handled but is disabled in the warmup time. Posting map file in the discord.

NOTE: The timeout is just set to 3 seconds right now. This will need to be changed.
NOTE X2: I kept the debug log for the item breaking functionality, just so testers can easily verify what items are being charged upkeep. Example: If you start with a sword, and then switch to a spear on the website. When the chest is used you should be charged upkeep for the duration you used the sword.

NOTE X3: There are probably still some things I need to clean up. And I know I know that I handle the match time in ms but the reward server is made to handle it in s.

![image](https://github.com/user-attachments/assets/f8112160-a46f-461f-954f-3573f3100462)
