### PR TITLE
mod: add warmup reward check if not enough players to start

### DIFF
--- a/src/Module.Server/Modes/Warmup/CrpgWarmupComponent.cs
+++ b/src/Module.Server/Modes/Warmup/CrpgWarmupComponent.cs
@@ -190,7 +190,8 @@ internal class CrpgWarmupComponent : MultiplayerWarmupComponent
     private void RewardUsers()
     {
         _rewardTickTimer ??= new MissionTimer(duration: WarmupRewardTimer);
-        if (_rewardTickTimer.Check(reset: true))
+        // only set multi and reward players if not enough to start game
+        if (_rewardTickTimer.Check(reset: true) && MultiplayerOptions.OptionType.MinNumberOfPlayersForMatchStart.GetIntValue() - _players.Count() > 0)
         {
             OnWarmupRewardTick?.Invoke(_rewardTickTimer.GetTimerDuration());
         }


### PR DESCRIPTION
fixes #523 - will probably need to monitor as the first reward tick is only 30 seconds which may not be enough time for players to reach the threshold.