### PR TITLE
webUI: Increase duration items are new

### DIFF
--- a/src/WebUI/src/services/item-service.ts
+++ b/src/WebUI/src/services/item-service.ts
@@ -789,7 +789,7 @@ export const reforgeCostByRank: Record<ItemRank, number> = {
   3: itemReforgeCostPerRank[3],
 }
 
-export const itemIsNewDays = 1
+export const itemIsNewDays = 14
 
 export const isWeaponBySlot = (slot: ItemSlot) => weaponSlots.includes(slot)
 


### PR DESCRIPTION
Increase ItemIsNewDays to 14 

Increases the duration Items are considered 'New' on the site to 14 days.

This ensures a wider period in which items are considered New enabling faster and easier testing/noticing of the fresh items we add into the mod.