### PR TITLE
mod: Re-enforce pierce-only damage type for mount rearing mechanics

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -396,6 +396,24 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
         return randomNumber / 10f < Math.Pow(attackerPower / defenderDefendPower / 2.5f, 1.8f) * 100f;
     }
 
+    // MissionCombatMechanicsHelper.cs/DecideMountRearedByBlow
+    public override bool DecideMountRearedByBlow(
+        Agent attackerAgent,
+        Agent victimAgent,
+        in AttackCollisionData collisionData,
+        WeaponComponentData attackerWeapon,
+        in Blow blow)
+    {
+        // Only allow if damage type is Pierce
+        if (blow.DamageType != DamageTypes.Pierce)
+        {
+            return false;
+        }
+
+        // Call the original/base logic (which evolves with TW updates)
+        return base.DecideMountRearedByBlow(attackerAgent, victimAgent, in collisionData, attackerWeapon, in blow);
+    }
+
     private int GetSkillValue(IAgentOriginBase agentOrigin, SkillObject skill)
     {
         if (agentOrigin is CrpgBattleAgentOrigin crpgOrigin)


### PR DESCRIPTION
Enforce pierce-only damage type for mount rearing mechanics.

Mounts can only be forced into a rear state if the blow's damage type is Pierce. 
This aligns with gameplay intent to reward proper weapon use (e.g., spears, lances) for dismount maneuvers, and avoids unintended rears from other damage types like blunt or cut.

This change preserves all existing TaleWorlds base logic by deferring to the original `DecideMountRearedByBlow()` implementation after verifying the damage type. The goal is to maintain compatibility with upstream changes while enforcing custom gameplay rules in Crpg.

See: MissionCombatMechanicsHelper.DecideMountRearedByBlow in current compiled TW logic for reference.

Also see: https://github.com/verdie-g/crpg/commit/273afcf4977e61309531ed4a05d440d12ff2e2c1 & https://github.com/verdie-g/crpg/commit/9d183f60f633afca82488840ecc732922932818a for ref on where this was sourced from