### PR TITLE
mod: When VIP is already dead, highlighting causes a client crash.

### DIFF
--- a/src/Module.Client/GUI/CrpgMissionMarkerVM.cs
+++ b/src/Module.Client/GUI/CrpgMissionMarkerVM.cs
@@ -269,7 +269,7 @@ internal class CrpgMissionMarkerVm : ViewModel
 
         if (dtvClient.VipAgent != null)
         {
-            if (dtvClient.VipAgent.Health > 0)
+            if (dtvClient.VipAgent.Health > 0f)
             {
                 if (enabled && !_isVipOutlined)
                 {

--- a/src/Module.Client/GUI/CrpgMissionMarkerVM.cs
+++ b/src/Module.Client/GUI/CrpgMissionMarkerVM.cs
@@ -269,16 +269,19 @@ internal class CrpgMissionMarkerVm : ViewModel
 
         if (dtvClient.VipAgent != null)
         {
-            if (enabled && !_isVipOutlined)
+            if (dtvClient.VipAgent.Health > 0)
             {
-                uint focusedContourColor = new TaleWorlds.Library.Color(1f, 0.84f, 0.35f, 1f).ToUnsignedInteger();
-                dtvClient.VipAgent.AgentVisuals?.SetContourColor(focusedContourColor, true);
-                _isVipOutlined = true;
-            }
-            else if (!enabled && _isVipOutlined)
-            {
-                dtvClient.VipAgent.AgentVisuals?.SetContourColor(null);
-                _isVipOutlined = false;
+                if (enabled && !_isVipOutlined)
+                {
+                    uint focusedContourColor = new TaleWorlds.Library.Color(1f, 0.84f, 0.35f, 1f).ToUnsignedInteger();
+                    dtvClient.VipAgent.AgentVisuals?.SetContourColor(focusedContourColor, true);
+                    _isVipOutlined = true;
+                }
+                else if (!enabled && _isVipOutlined)
+                {
+                    dtvClient.VipAgent.AgentVisuals?.SetContourColor(null);
+                    _isVipOutlined = false;
+                }
             }
         }
     }


### PR DESCRIPTION
Added a check that the agent is still alive.

System.AccessViolationException: 'Attempted to read or write protected memory. This is often an indication that other memory is corrupt.'

The error occurs when trying to access the agents visuals. Doing a null check on AgentVisuals does not solve the issue.

Its kind of an ugly looking change in the diff. I just added an extra check.