### PR TITLE
Lower DamageInterruptAttackThreshold for cut from 9 to 7

### DIFF
--- a/src/Module.Server/ModuleData/managed_core_parameters.xml
+++ b/src/Module.Server/ModuleData/managed_core_parameters.xml
@@ -29,7 +29,7 @@
 
     <!-- damage related -->
     <managed_core_parameter id="DamageInterruptAttackthresholdPierce" value="9"/>
-    <managed_core_parameter id="DamageInterruptAttackthresholdCut" value="9"/>
+    <managed_core_parameter id="DamageInterruptAttackthresholdCut" value="7"/>
     <managed_core_parameter id="DamageInterruptAttackthresholdBlunt" value="9"/>
     <managed_core_parameter id="MakesRearAttackDamageThreshold" value="15.0"/>
     <managed_core_parameter id="MissileMinimumDamageToStick" value="3.0"/>


### PR DESCRIPTION
Lower DamageInterruptAttackThreshold for cut from 9 to 7

Glance threshold currently sets the minimum range for a stun to occur as being 9 damage, often cut (more likely to deal less damage to people in armour) hits below this threshold resulting in no stun occurring. This is frustrating for combat. Blunt and Pierce tend to do more damage than this or will do more damage even on a swing that should be a glance, hence why only Cut threshold is being lowered.

This change is being made for the purpose of improving performance of cut weapons without a direct buff to their damage.