### PR TITLE
2x final bow weight and 1.5x final arrow weight

### DIFF
--- a/src/Module.Client/DataExport/ItemExporter.cs
+++ b/src/Module.Client/DataExport/ItemExporter.cs
@@ -1133,7 +1133,7 @@ internal class ItemExporter : IDataExporter
             int.Parse(weaponNode.Attributes!["accuracy"].Value),
             weaponNode.Attributes!["item_usage"].Value == "long_bow",
             heirloomLevel);
-        return tier * int.Parse(weaponNode.Attributes!["thrust_damage"].Value) / 100f;
+        return 2f * tier * int.Parse(weaponNode.Attributes!["thrust_damage"].Value) / 100f;
     }
 
     private static float ModifyArrowWeight(XmlNode nonHeirloomNode, XmlNode node, ItemObject.ItemTypeEnum type, int heirloomLevel)
@@ -1153,7 +1153,7 @@ internal class ItemExporter : IDataExporter
                 weaponNode.Attributes!["thrust_damage"].Value)
             * CrpgItemValueModel.CalculateDamageTypeFactorForAmmo(damagetype) / 12f, 0f, 1f));
 
-        return weight;
+        return weight * 1.5f;
     }
 
     private static void ModifyChildHeirloomNodesAttribute(


### PR DESCRIPTION
CrafterHarmonyExporter change to 2x final bow weight and 1.5x final arrow weight.

This is to significantly increase the weight that archers carry based on their primary weaponry. This should lead to the outcomes:

1. Archers maintain their equipment as is, and face a significant penalty to their speed, making them easier to catch by infantry. 
2. Archers reduce the weight of their armor and/or sidearm and/or quiver. This will reduce their survivability to cavalry, other ranged and once caught in melee.

The intention is to make the heavily armoured archer (45+), who can move fast and pump out high damage non-existent. Kiting archers may still be possible under this, but they would have to consider a worse bow, worse arrows and/or worse armour for the trade off.

This is a direct nerf to archery and I am fully aware compensation may be in order in other parts of their loadout. Reducing mobility could come with a trade off for increased damage, although this may come naturally if people shift to lower ammo, higher damage arrows.