### PR TITLE
mod: Fix remaining 1h stab issues and adjust thrust collision parameters

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -471,11 +471,6 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                     props.WeaponUnsteadyEndTime = 3.0f + weaponSkill * 0.01f;
                 }
 
-                if (equippedItem.WeaponClass is WeaponClass.Mace or WeaponClass.OneHandedAxe or WeaponClass.OneHandedSword or WeaponClass.Dagger)
-                {
-                    props.ThrustOrRangedReadySpeedMultiplier *= 0.82f;
-                }
-
                 if (equippedItem.WeaponClass is WeaponClass.TwoHandedPolearm)
                 {
                     props.HandlingMultiplier *= 1.1f;

--- a/src/Module.Server/ModuleData/combat_parameters.xml
+++ b/src/Module.Server/ModuleData/combat_parameters.xml
@@ -31,8 +31,8 @@
     <combat_parameter
 			id="onehanded_thrust"
 			collision_check_starting_percent="0.0"
-			collision_damage_starting_percent="0.1"
-			collision_check_ending_percent="0.57"
+			collision_damage_starting_percent="0.25"
+			collision_check_ending_percent="1"
 			vertical_rot_limit_multiplier_up="thrust_vertical_rot_limit"
 			vertical_rot_limit_multiplier_down="thrust_vertical_rot_limit"
 			left_rider_rot_limit="thrust_rider_rot_limit_left"


### PR DESCRIPTION
Remove slowdown applied to 1h thrust, fix collision parameters to line up with original animation.

Based on feedback provided by users (special thank you to Defodijabox) and further testing, it was discovered that a slowdown that did not need to be present was still in place for 1h, furthermore, this was also obscuring deeper issues with 1h thrust attacks. This change removes a now unnecessary ready speed penalty for 1h weapons and addresses separate issues affecting thrust performance.

See the following video for reference:
https://cdn.discordapp.com/attachments/1186742521255182356/1376356318889115698/BeforeAfter1HSTAB.mp4?ex=68350735&is=6833b5b5&hm=78f30dcc5fe66174b556602f99fa1a097734410307e846e6475006bbe2f5e03b&