### PR TITLE
mod: Increased STR req for longer weapons

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -593,7 +593,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
 
     private int MaxWeaponLengthForStrLevel(int strengthSkill)
     {
-        int uncappedMaxWeaponLength = (int)(22 + (strengthSkill - 3) * 7.5 + Math.Pow(Math.Min(strengthSkill - 3, 24) * 0.133352143f, 8f));
+        int uncappedMaxWeaponLength = (int)(22 + (strengthSkill - 3) * 7.5 + Math.Pow(Math.Min(strengthSkill - 3, 24) * 0.115f, 7.75f));
         return Math.Min(uncappedMaxWeaponLength, 650);
     }
 

--- a/src/WebUI/src/services/characters-service.ts
+++ b/src/WebUI/src/services/characters-service.ts
@@ -414,7 +414,7 @@ export const computeSpeedStats = (
     1.5,
   )
   const maxWeaponLength = Math.min(
-    22 + (strength - 3) * 7.5 + (Math.min(strength - 3, 24) * 0.133352143) ** 8,
+      22 + (strength - 3) * 7.5 + (Math.min(strength - 3, 24) * 0.115) ** 7.75,
     650,
   )
   const timeToMaxSpeedWeaponLenghthTerm = Math.max(


### PR DESCRIPTION
Increased the strength requirement to have no movement penalty when attacking, to match with pike changes where new maximum reach weapon is 400. The intention is to further limit agility build from combining very high movement speeds with very long weapons. As this only applies during attacks, won't affect general movement speed or eg, ranged taking a slightly longer melee weapon until they need to use it.

~~I am unsure if/how this would require updating to show on the website correct, or if Orle has performed magic and it's automatic.~~ Updated the WebUI section

Tested changes and works as intended

![image](https://github.com/user-attachments/assets/8abeee53-6957-4130-af1c-84b70a9ca40d)

![image](https://github.com/user-attachments/assets/7e2d7825-e84f-4a09-800e-b6f7549ed50d)

