### PR TITLE
mod: Time to reach maximum speed +50% when holding a ranged weapon

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -369,7 +369,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
             // Ranged Behavior
             if (equippedItem.IsRangedWeapon)
             {
-                props.TopSpeedReachDuration += 1.0f;
+                props.TopSpeedReachDuration += 1.5f;
                 props.ThrustOrRangedReadySpeedMultiplier = equippedItem.ThrustSpeed / 160f + 0.0015f * itemSkill;
                 float maxMovementAccuracyPenaltyMultiplier = Math.Max(0.0f, 1.0f - weaponSkill / 500.0f);
                 float weaponMaxMovementAccuracyPenalty = 0.125f * maxMovementAccuracyPenaltyMultiplier;


### PR DESCRIPTION
Increased TopSpeedReachDuration by 0.5s, from 1.0 seconds to 1.5 seconds, for characters holding a ranged weapon.

Edit: Poor wording in my original title, I don not want to make ranged have a +50% time to top speed based off the existing formula, just increase their existing slowdown of 1s by 0.5s