### PR TITLE
mod: Add 10% damage bonus for 1h swords under strict conditions

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -158,75 +158,9 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             finalDamage *= 0.23f; // Decrease damage from couched lance.
         }
 
-        if (weapon.CurrentUsageItem.WeaponClass == WeaponClass.OneHandedSword
-            && collisionData.StrikeType != (int)StrikeType.Thrust
-            && collisionData.DamageType == (int)DamageTypes.Cut)
+        if (IsSwashbuckler(weapon, collisionData, attackInformation.AttackerAgent))
         {
-            Agent attackerAgent = attackInformation.AttackerAgent;
-
-            bool hasRangedWeapon = false;
-            bool hasShield = false;
-
-            // Check offhand for shield
-            var offhandItem = attackerAgent.Equipment[EquipmentIndex.Weapon2];
-            if (offhandItem.Item?.PrimaryWeapon?.IsShield == true)
-            {
-                hasShield = true;
-            }
-
-            // Check inventory for ranged, shield, or alternate throwable mode
-            for (int i = 0; i < (int)EquipmentIndex.NumAllWeaponSlots; i++)
-            {
-                var equipmentElement = attackerAgent.Equipment[i];
-                var item = equipmentElement.Item;
-                if (item == null)
-                {
-                    continue;
-                }
-
-                var usage = item.PrimaryWeapon;
-                if (usage == null)
-                {
-                    continue;
-                }
-
-                if (!hasRangedWeapon)
-                {
-                    // Mark as ranged if it's an actual ranged weapon with ammo, or has any throwable alternate mode
-                    bool isAmmoEmpty = equipmentElement.Amount == 0 && usage.IsConsumable;
-                    bool hasAlternateThrowable = false;
-
-                    for (int j = 0; j < item.WeaponComponent?.Weapons?.Count; j++)
-                    {
-                        var altUsage = item.WeaponComponent.Weapons[j];
-                        if (altUsage != usage && altUsage.IsConsumable && altUsage.IsRangedWeapon)
-                        {
-                            hasAlternateThrowable = true;
-                            break;
-                        }
-                    }
-
-                    if ((usage.IsRangedWeapon && !isAmmoEmpty) || hasAlternateThrowable)
-                    {
-                        hasRangedWeapon = true;
-                    }
-                }
-
-                if (!hasShield && usage.IsShield)
-                {
-                    hasShield = true;
-                }
-
-                if (hasShield || hasRangedWeapon)
-                {
-                    break;
-                }
-            }
-
-            if (!attackerAgent.HasMount && !hasShield && !hasRangedWeapon)
-            {
-                finalDamage *= 1.10f;
-            }
+            finalDamage *= 1.10f;
         }
 
         return finalDamage;
@@ -535,6 +469,74 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
         }
 
         return false;
+    }
+
+    private bool IsSwashbuckler(MissionWeapon weapon, AttackCollisionData collisionData, Agent attackerAgent)
+    {
+        if (weapon.CurrentUsageItem.WeaponClass != WeaponClass.OneHandedSword
+            || collisionData.StrikeType == (int)StrikeType.Thrust
+            || collisionData.DamageType != (int)DamageTypes.Cut)
+        {
+            return false;
+        }
+
+        bool hasRangedWeapon = false;
+        bool hasShield = false;
+
+        var offhandItem = attackerAgent.Equipment[EquipmentIndex.Weapon2];
+        if (offhandItem.Item?.PrimaryWeapon?.IsShield == true)
+        {
+            hasShield = true;
+        }
+
+        for (int i = 0; i < (int)EquipmentIndex.NumAllWeaponSlots; i++)
+        {
+            var equipmentElement = attackerAgent.Equipment[i];
+            var item = equipmentElement.Item;
+            if (item == null)
+            {
+                continue;
+            }
+
+            var usage = item.PrimaryWeapon;
+            if (usage == null)
+            {
+                continue;
+            }
+
+            if (!hasRangedWeapon)
+            {
+                bool isAmmoEmpty = equipmentElement.Amount == 0 && usage.IsConsumable;
+                bool hasAlternateThrowable = false;
+
+                for (int j = 0; j < item.WeaponComponent?.Weapons?.Count; j++)
+                {
+                    var altUsage = item.WeaponComponent.Weapons[j];
+                    if (altUsage != usage && altUsage.IsConsumable && altUsage.IsRangedWeapon)
+                    {
+                        hasAlternateThrowable = true;
+                        break;
+                    }
+                }
+
+                if ((usage.IsRangedWeapon && !isAmmoEmpty) || hasAlternateThrowable)
+                {
+                    hasRangedWeapon = true;
+                }
+            }
+
+            if (!hasShield && usage.IsShield)
+            {
+                hasShield = true;
+            }
+
+            if (hasShield || hasRangedWeapon)
+            {
+                break;
+            }
+        }
+
+        return !attackerAgent.HasMount && !hasShield && !hasRangedWeapon;
     }
 
     private int GetGloveArmor(IAgentOriginBase agentOrigin)

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -174,7 +174,7 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                 hasShield = true;
             }
 
-            // Check inventory for ranged and shield
+            // Check inventory for ranged, shield, or alternate throwable mode
             for (int i = 0; i < (int)EquipmentIndex.NumAllWeaponSlots; i++)
             {
                 var equipmentElement = attackerAgent.Equipment[i];
@@ -190,9 +190,26 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
                     continue;
                 }
 
-                if (!hasRangedWeapon && usage.IsRangedWeapon)
+                if (!hasRangedWeapon)
                 {
-                    hasRangedWeapon = true;
+                    // Mark as ranged if it's an actual ranged weapon with ammo, or has any throwable alternate mode
+                    bool isAmmoEmpty = equipmentElement.Amount == 0 && usage.IsConsumable;
+                    bool hasAlternateThrowable = false;
+
+                    for (int j = 0; j < item.WeaponComponent?.Weapons?.Count; j++)
+                    {
+                        var altUsage = item.WeaponComponent.Weapons[j];
+                        if (altUsage != usage && altUsage.IsConsumable && altUsage.IsRangedWeapon)
+                        {
+                            hasAlternateThrowable = true;
+                            break;
+                        }
+                    }
+
+                    if ((usage.IsRangedWeapon && !isAmmoEmpty) || hasAlternateThrowable)
+                    {
+                        hasRangedWeapon = true;
+                    }
                 }
 
                 if (!hasShield && usage.IsShield)

--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -158,6 +158,60 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             finalDamage *= 0.23f; // Decrease damage from couched lance.
         }
 
+        if (weapon.CurrentUsageItem.WeaponClass == WeaponClass.OneHandedSword
+            && collisionData.StrikeType != (int)StrikeType.Thrust
+            && collisionData.DamageType == (int)DamageTypes.Cut)
+        {
+            Agent attackerAgent = attackInformation.AttackerAgent;
+
+            bool hasRangedWeapon = false;
+            bool hasShield = false;
+
+            // Check offhand for shield
+            var offhandItem = attackerAgent.Equipment[EquipmentIndex.Weapon2];
+            if (offhandItem.Item?.PrimaryWeapon?.IsShield == true)
+            {
+                hasShield = true;
+            }
+
+            // Check inventory for ranged and shield
+            for (int i = 0; i < (int)EquipmentIndex.NumAllWeaponSlots; i++)
+            {
+                var equipmentElement = attackerAgent.Equipment[i];
+                var item = equipmentElement.Item;
+                if (item == null)
+                {
+                    continue;
+                }
+
+                var usage = item.PrimaryWeapon;
+                if (usage == null)
+                {
+                    continue;
+                }
+
+                if (!hasRangedWeapon && usage.IsRangedWeapon)
+                {
+                    hasRangedWeapon = true;
+                }
+
+                if (!hasShield && usage.IsShield)
+                {
+                    hasShield = true;
+                }
+
+                if (hasShield || hasRangedWeapon)
+                {
+                    break;
+                }
+            }
+
+            if (!attackerAgent.HasMount && !hasShield && !hasRangedWeapon)
+            {
+                finalDamage *= 1.10f;
+            }
+        }
+
         return finalDamage;
     }
 


### PR DESCRIPTION
Add 10% damage bonus for 1h swords under strict conditions.

This change applies a 10% melee damage bonus to attacks made with one-handed swords, but only under the following conditions:
- The attack is a swing (not a thrust)
- The damage type is cut
- The agent is not mounted
- The agent has no shield equipped (offhand or in inventory)
- The agent has no ranged weapons in their inventory

The logic is evaluated per attack, ensuring that the bonus dynamically reflects the agent's current state. This incentivizes a reason to play a 1h Sword without a shield.

This has been tested in-game to confirm all of the conditions work as expected.

Video for reference:
https://cdn.discordapp.com/attachments/1186742521255182356/1377032789249101856/1hSwashBucklerBuff2.mp4?ex=68377d38&is=68362bb8&hm=677208b877dc1298df9176f4fd4a626f50c1c025d436058a13edecebd0712d8d&