### PR TITLE
Mounted combat speed

### DIFF
--- a/src/Module.Server/Common/CombatHelper.cs
+++ b/src/Module.Server/Common/CombatHelper.cs
@@ -1,0 +1,21 @@
+﻿using TaleWorlds.Library;
+
+namespace Crpg.Module.Helpers
+{
+    public static class CrpgCombatHelpers
+    {
+        /// Computes the penalty multiplier applied to mount stats when wielding overly long weapons for a given strength.
+        public static float ComputeMountedWeaponPenalty(int strength, float weaponLength)
+        {
+            float maxLength = MaxWeaponLengthForStrLevel(strength);
+            float rawRatio = maxLength / weaponLength;
+            return MBMath.ClampFloat(MBMath.Lerp(0.5f, 1.0f, rawRatio), 0.5f, 1.0f);
+        }
+
+        public static float MaxWeaponLengthForStrLevel(int strengthSkill)
+        {
+            int uncapped = (int)(22 + (strengthSkill - 3) * 7.5 + System.Math.Pow(System.Math.Min(strengthSkill - 3, 24) * 0.115f, 7.75f));
+            return System.Math.Min(uncapped, 650);
+        }
+    }
+}

--- a/src/Module.Server/Common/CrpgCharacterBuilder.cs
+++ b/src/Module.Server/Common/CrpgCharacterBuilder.cs
@@ -59,6 +59,7 @@ internal static class CrpgCharacterBuilder
             AddEquipment(equipment, index, equippedItem.UserItem.ItemId);
         }
 
+        AddEquipment(equipment, EquipmentIndex.Horse, "crpg_mount1_courser_14_v2_h0");
         return equipment;
     }
 

--- a/src/Module.Server/Common/CrpgConstants.cs
+++ b/src/Module.Server/Common/CrpgConstants.cs
@@ -1,7 +1,7 @@
 ﻿namespace Crpg.Module.Common;
 
 // To synchronize with Crpg.Application.Common.Constants.
-public class CrpgConstants
+internal class CrpgConstants
 {
     public int WeaponProficiencyPointsForAgility { get; set; }
     public float[] WeaponProficiencyPointsForWeaponMasterCoefs { get; set; } = Array.Empty<float>();

--- a/src/Module.Server/Common/CrpgConstants.cs
+++ b/src/Module.Server/Common/CrpgConstants.cs
@@ -1,7 +1,7 @@
 ﻿namespace Crpg.Module.Common;
 
 // To synchronize with Crpg.Application.Common.Constants.
-internal class CrpgConstants
+public class CrpgConstants
 {
     public int WeaponProficiencyPointsForAgility { get; set; }
     public float[] WeaponProficiencyPointsForWeaponMasterCoefs { get; set; } = Array.Empty<float>();

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -251,6 +251,29 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         props.MountSpeed = (mount.GetModifiedMountSpeed(in mountHarness) + 1) * 0.209f * ridingImpactOnSpeed * weightImpactOnSpeed;
         props.TopSpeedReachDuration = Game.Current.BasicModels.RidingModel.CalculateAcceleration(in mount, in mountHarness, ridingSkill);
         props.MountDashAccelerationMultiplier = 1f / (2f + 8f * harnessWeightPercentage); // native between 1 and 0.1 . cRPG between 0.5 and 0.1
+
+        // Mounted penalty using same calculation as combat speed from strength and weapon length
+        if (agent.RiderAgent is Agent rider)
+        {
+            int strengthSkill = GetEffectiveSkill(rider, CrpgSkills.Strength);
+            EquipmentIndex weaponIndex = rider.GetWieldedItemIndex(Agent.HandIndex.MainHand);
+            WeaponComponentData? riderWeapon = weaponIndex != EquipmentIndex.None
+                ? rider.Equipment[weaponIndex].CurrentUsageItem
+                : null;
+
+            if (riderWeapon != null)
+            {
+                float weaponLengthPenalty = Math.Min(
+                    MBMath.Lerp(0.8f, 1f, MaxWeaponLengthForStrLevel(strengthSkill) / riderWeapon.WeaponLength),
+                    1f
+                );
+
+                props.MountManeuver *= weaponLengthPenalty;
+                props.MountSpeed *= weaponLengthPenalty;
+                props.MountDashAccelerationMultiplier *= weaponLengthPenalty;
+                props.MountChargeDamage *= weaponLengthPenalty;
+            }
+        }
     }
 
     // WARNING : for some reasone UpdateHumanAgentStats is called twice everytime there is a change (respawn or weapon switch)

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -229,6 +229,8 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         props.ArmorTorso = mountHarness.Item != null ? mountHarness.GetModifiedMountBodyArmor() : 0;
         props.MountChargeDamage = mount.GetModifiedMountCharge(in mountHarness) * 0.01f;
         props.MountDifficulty = mount.Item.Difficulty;
+
+        ApplyMountedWeaponPenalty(agent, props);
     }
 
     private void UpdateMountAgentStats(Agent agent, AgentDrivenProperties props)
@@ -251,6 +253,8 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         props.MountSpeed = (mount.GetModifiedMountSpeed(in mountHarness) + 1) * 0.209f * ridingImpactOnSpeed * weightImpactOnSpeed;
         props.TopSpeedReachDuration = Game.Current.BasicModels.RidingModel.CalculateAcceleration(in mount, in mountHarness, ridingSkill);
         props.MountDashAccelerationMultiplier = 1f / (2f + 8f * harnessWeightPercentage); // native between 1 and 0.1 . cRPG between 0.5 and 0.1
+
+        ApplyMountedWeaponPenalty(agent, props);
 
         // Mounted penalty using same calculation as combat speed from strength and weapon length
         if (agent.RiderAgent is Agent rider)
@@ -387,6 +391,9 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 props.SwingSpeedMultiplier *= HasSwingDamage(primaryItem) ? cappedSwingSpeedFactor : 1f;
                 // Thrustspeed Nerf on Horseback
                 props.ThrustOrRangedReadySpeedMultiplier *= 0.84f;
+
+                ApplyMountedWeaponPenalty(agent.MountAgent!, agent.MountAgent!.AgentDrivenProperties);
+                UpdateMountAgentStats(agent.MountAgent!, agent.MountAgent!.AgentDrivenProperties);
             }
 
             // Ranged Behavior
@@ -646,5 +653,38 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         }
 
         return equippedItem.WeaponComponent.Weapons.Any(a => a.SwingDamage > 0);
+    }
+    private void ApplyMountedWeaponPenalty(Agent agent, AgentDrivenProperties props)
+    {
+        if (agent.RiderAgent is Agent rider)
+        {
+            int strengthSkill = GetEffectiveSkill(rider, CrpgSkills.Strength);
+            float worstPenalty = 1.0f;
+
+            foreach (EquipmentIndex index in Enum.GetValues(typeof(EquipmentIndex)))
+            {
+                if (index < EquipmentIndex.Weapon0 || index > EquipmentIndex.Weapon3)
+                    continue;
+
+                WeaponComponentData? weapon = rider.Equipment[index].CurrentUsageItem;
+
+                if (weapon == null || weapon.IsRangedWeapon)
+                    continue;
+
+                float rawRatio = MaxWeaponLengthForStrLevel(strengthSkill) / weapon.WeaponLength;
+                float penalty = MathF.Clamp(MBMath.Lerp(0.5f, 1.0f, rawRatio), 0.5f, 1.0f); // never less than 0.5
+
+                if (penalty < worstPenalty)
+                    worstPenalty = penalty;
+            }
+
+            if (worstPenalty < 1.0f)
+            {
+                props.MountManeuver *= worstPenalty;
+                props.MountSpeed *= worstPenalty;
+                props.MountDashAccelerationMultiplier *= worstPenalty;
+                props.MountChargeDamage *= worstPenalty;
+            }
+        }
     }
 }

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -9,7 +9,7 @@ namespace Crpg.Module.Common.Models;
 /// <summary>
 /// Mostly copied from <see cref="MultiplayerAgentStatCalculateModel"/> but with the class division system removed.
 /// </summary>
-internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
+public class CrpgAgentStatCalculateModel : AgentStatCalculateModel
 {
     private static readonly HashSet<WeaponClass> WeaponClassesAffectedByPowerStrike = new()
     {
@@ -233,7 +233,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         ApplyMountedWeaponPenalty(agent, props);
     }
 
-    private void UpdateMountAgentStats(Agent agent, AgentDrivenProperties props)
+    public void UpdateMountAgentStats(Agent agent, AgentDrivenProperties props)
     {
         EquipmentElement mount = agent.SpawnEquipment[EquipmentIndex.ArmorItemEndSlot];
         EquipmentElement mountHarness = agent.SpawnEquipment[EquipmentIndex.HorseHarness];
@@ -671,8 +671,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 if (weapon == null || weapon.IsRangedWeapon)
                     continue;
 
-                float rawRatio = MaxWeaponLengthForStrLevel(strengthSkill) / weapon.WeaponLength;
-                float penalty = MathF.Clamp(MBMath.Lerp(0.5f, 1.0f, rawRatio), 0.5f, 1.0f); // never less than 0.5
+                float penalty = CrpgCombatHelpers.ComputeMountedWeaponPenalty(strengthSkill, weapon.WeaponLength);
 
                 if (penalty < worstPenalty)
                     worstPenalty = penalty;


### PR DESCRIPTION
Applies the same % (currently maxing at 50% instead of 20% for ease of testing) penalty as infantry receive to mount speed, manurver, chrage damage and dash accelertation based on strength and weapon length in inventory (not in hands) when:

- Spawning in
- Mounting a horse

Does not yet apply when picking up or dropping a weapon whilst already mounted. Seems like it might need harmony for that and would appreciate some input if anyone can.