### PR TITLE
webAPI/webUI: Remove Xbox logon

### DIFF
--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -129,31 +129,6 @@ builder.Services.AddOpenIddict()
             webProviderAdded = true;
         }
 
-        string? microsoftClientId = builder.Configuration["Microsoft:ClientId"];
-        string? microsoftClientSecret = builder.Configuration["Microsoft:ClientSecret"];
-
-        if (microsoftClientId != null && microsoftClientSecret != null)
-        {
-            webIntegrationBuilder.AddMicrosoft(microsoft =>
-            {
-                microsoft.SetClientId(microsoftClientId)
-                    .SetClientSecret(microsoftClientSecret)
-                    .SetRedirectUri("connect/callback-microsoft")
-                    // Use "consumers" once https://github.com/openiddict/openiddict-core/pull/1765 is released.
-                    .SetTenant("9188040d-6c67-4c5b-b112-36a304b66dad")
-                    .AddScopes("XboxLive.signin");
-            });
-
-            options.AddEventHandler(XboxUserInfoHandler.Descriptor);
-
-            webProviderAdded = true;
-        }
-
-        if (!webProviderAdded)
-        {
-            return;
-        }
-
         options.AllowAuthorizationCodeFlow();
 
         options.AddDevelopmentEncryptionCertificate()

--- a/src/WebUI/src/models/platform.ts
+++ b/src/WebUI/src/models/platform.ts
@@ -1,5 +1,4 @@
 export enum Platform {
   Steam = 'Steam',
   EpicGames = 'EpicGames',
-  Microsoft = 'Microsoft',
 }

--- a/src/WebUI/src/services/platform-service.ts
+++ b/src/WebUI/src/services/platform-service.ts
@@ -2,6 +2,5 @@ import { Platform } from '~/models/platform'
 
 export const platformToIcon: Record<Platform, string> = {
   [Platform.EpicGames]: 'epic-games',
-  [Platform.Microsoft]: 'xbox',
   [Platform.Steam]: 'steam-transparent',
 }


### PR DESCRIPTION
Remove Xbox/Microsoft logon portion of logon button.

Following https://github.com/crpg2/crpg/pull/551 I noted that Xbox still had the logon method listed under our Logon button which would inevitably fail out in an error when used. This change removes some API/UI components that are keeping this in place.
