### PR TITLE
One handed polearm global thrust speed reduction

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -477,6 +477,12 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 }
 
                 props.CombatMaxSpeedMultiplier *= ImpactofStrAndWeaponLengthOnCombatMaxSpeedMultiplier(equippedItem.WeaponLength, strengthSkill);
+
+                // Thrust speed nerf for OneHandedPolearms
+                if (equippedItem.WeaponClass == WeaponClass.OneHandedPolearm)
+                {
+                    props.ThrustOrRangedReadySpeedMultiplier *= 0.1f;
+                }
             }
 
             // Mounted Archery

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -481,7 +481,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 // Thrust speed nerf for OneHandedPolearms
                 if (equippedItem.WeaponClass == WeaponClass.OneHandedPolearm)
                 {
-                    props.ThrustOrRangedReadySpeedMultiplier *= 0.1f;
+                    props.ThrustOrRangedReadySpeedMultiplier *= 0.9f;
                 }
             }
 


### PR DESCRIPTION
Reduced one handed polearm final thrust speed by 10%. Not achievable through crafting because of the crafting process, would tank handling.

One handed polearms, whether it be on foot as hoplite or mounted cavalry, are extremely fast to stab even with low WPFs. A reduction in their thrust speed will make them much more unusable at low WPFs and potentially alleviate some issues we are seeing with instant stabs.