### PR TITLE
Increase default HP by 10

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -30,7 +30,7 @@
   "highLevelCutoff": 30,
   "defaultStrength": 3,
   "defaultAgility": 3,
-  "defaultHealthPoints": 60, /* A 33 STR, 3 AGI character with 11 IF would reach 137 HP. */
+  "defaultHealthPoints": 70, /* A 33 STR, 3 AGI character with 11 IF would reach 137 HP. */
   "defaultGeneration": 0,
   "defaultAttributePoints": 1,
   "attributePointsPerLevel": 1,


### PR DESCRIPTION
Increased player starting HP by 10 (60 -> 70) to slightly raise the TTK by 1 hit for armoured melee characters, whilst still retaining the "squishiness" of low armour and/or low STR characters