### PR TITLE
Increased maximum combat speed

### DIFF
--- a/src/Module.Server/ModuleData/managed_core_parameters.xml
+++ b/src/Module.Server/ModuleData/managed_core_parameters.xml
@@ -23,7 +23,7 @@
     <managed_core_parameter id="QuadrupedalRadius" value="0.8"/>
     <!--Also used in native_paramaters.xml-->
     <managed_core_parameter id="BipedalCombatSpeedMinMultiplier" value="0.82"/>
-    <managed_core_parameter id="BipedalCombatSpeedMaxMultiplier" value="0.94"/>
+    <managed_core_parameter id="BipedalCombatSpeedMaxMultiplier" value="0.96"/>
     <managed_core_parameter id="BipedalRangedReadySpeedMultiplier" value="0.5"/>
     <managed_core_parameter id="BipedalRangedReloadSpeedMultiplier" value="0.25"/>
 


### PR DESCRIPTION
Increased maximum combat speed from 0.94 to 0.96. This value is in relation to the characters maximum movement speed, and is the speed that can be moved when blocking/attacking. Weapon length also plays an impact, this is the final modifier - short weapons are able to reach high combat speeds, so this will benefit short weapons/1h/shielders.