### PR TITLE
mod: Fix overly long hit window on 1h weapon stabs

### DIFF
--- a/src/Module.Server/ModuleData/combat_parameters.xml
+++ b/src/Module.Server/ModuleData/combat_parameters.xml
@@ -32,7 +32,7 @@
 			id="onehanded_thrust"
 			collision_check_starting_percent="0.0"
 			collision_damage_starting_percent="0.25"
-			collision_check_ending_percent="1"
+			collision_check_ending_percent="0.52"
 			vertical_rot_limit_multiplier_up="thrust_vertical_rot_limit"
 			vertical_rot_limit_multiplier_down="thrust_vertical_rot_limit"
 			left_rider_rot_limit="thrust_rider_rot_limit_left"


### PR DESCRIPTION
Tweak `collision_check_ending_percent` from `1` to `0.52` to reduce the duration during which 1h weapon stabs can register a hit after the animation begins.


This change addresses a noted problem where stabs continued to hit for too long after the stab portion of animation finished, leading to problematic behaviour in combat. Based on local testing the adjusted value better aligns the hit window with the animations visual end. Testing indicates improved behaviour without introducing further issues. Deploying this change to production will allow validation in actual combat and may result in further tuning based on feedback.