### PR TITLE
Salt/horse archery penalty

### DIFF
--- a/src/Module.Server/Common/CrpgCharacterBuilder.cs
+++ b/src/Module.Server/Common/CrpgCharacterBuilder.cs
@@ -59,6 +59,7 @@ internal static class CrpgCharacterBuilder
             AddEquipment(equipment, index, equippedItem.UserItem.ItemId);
         }
 
+        AddEquipment(equipment, EquipmentIndex.Horse, "crpg_mount1_courser_14_v2_h0");
         return equipment;
     }
 

--- a/src/Module.Server/Common/CrpgCharacterBuilder.cs
+++ b/src/Module.Server/Common/CrpgCharacterBuilder.cs
@@ -60,6 +60,8 @@ internal static class CrpgCharacterBuilder
         }
 
         AddEquipment(equipment, EquipmentIndex.Horse, "crpg_mount1_courser_14_v2_h0");
+        AddEquipment(equipment, EquipmentIndex.Weapon1, "crpg_stacked_steppe_arrows_v3_h0");
+        AddEquipment(equipment, EquipmentIndex.Weapon2, "crpg_hassun_yumi_v2_h0");
         return equipment;
     }
 

--- a/src/Module.Server/Common/CrpgCharacterBuilder.cs
+++ b/src/Module.Server/Common/CrpgCharacterBuilder.cs
@@ -59,9 +59,6 @@ internal static class CrpgCharacterBuilder
             AddEquipment(equipment, index, equippedItem.UserItem.ItemId);
         }
 
-        AddEquipment(equipment, EquipmentIndex.Horse, "crpg_mount1_courser_14_v2_h0");
-        AddEquipment(equipment, EquipmentIndex.Weapon1, "crpg_stacked_steppe_arrows_v3_h0");
-        AddEquipment(equipment, EquipmentIndex.Weapon2, "crpg_hassun_yumi_v2_h0");
         return equipment;
     }
 

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -501,18 +501,18 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 // Mounted skill penalty
                 props.WeaponInaccuracy /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
 
-                // Encumbrance-based inaccuracy penalty (neutral at 13, quadratic growth)
-                float encumbranceRatio = props.ArmorEncumbrance / 13.0f;
+                // Encumbrance-based inaccuracy penalty (neutral at 15, quadratic growth)
+                float encumbranceRatio = props.ArmorEncumbrance / 15.0f;
                 float encumbranceMultiplier = MathF.Max(
                     1.0f + (MathF.Pow(encumbranceRatio, 2f) - 1.0f) * 0.75f,
                     1.0f);
 
                 props.WeaponInaccuracy *= encumbranceMultiplier;
 
-                // Reload & thrust speed penalty: linear drop from 1.0 at 13 to 0.25 at 25
-                float reloadThrustMultiplier = props.ArmorEncumbrance <= 13f
+                // Reload & thrust speed penalty: linearly drops from 1.0 at 15 to 0.25 at 25
+                float reloadThrustMultiplier = props.ArmorEncumbrance <= 15f
                     ? 1.0f
-                    : MathF.Max(1.0f - ((props.ArmorEncumbrance - 13f) / (25f - 13f)) * 0.75f, 0.25f);
+                    : MathF.Max(1.0f - ((props.ArmorEncumbrance - 15f) / 10f) * 0.75f, 0.25f);
 
                 props.ReloadSpeed *= reloadThrustMultiplier;
                 props.ThrustOrRangedReadySpeedMultiplier *= reloadThrustMultiplier;

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -501,18 +501,18 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 // Mounted skill penalty
                 props.WeaponInaccuracy /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
 
-                // Encumbrance-based inaccuracy penalty (neutral at 10, quadratic growth)
-                float encumbranceRatio = totalEncumbrance / 10.0f;
+                // Encumbrance-based inaccuracy penalty (neutral at 13, quadratic growth)
+                float encumbranceRatio = props.ArmorEncumbrance / 13.0f;
                 float encumbranceMultiplier = MathF.Max(
                     1.0f + (MathF.Pow(encumbranceRatio, 2f) - 1.0f) * 0.75f,
                     1.0f);
 
                 props.WeaponInaccuracy *= encumbranceMultiplier;
 
-                // Reload & thrust speed penalty: linearly drops from 1.0 at 10 to 0.25 at 35
-                float reloadThrustMultiplier = totalEncumbrance <= 10f
+                // Reload & thrust speed penalty: linear drop from 1.0 at 13 to 0.25 at 25
+                float reloadThrustMultiplier = props.ArmorEncumbrance <= 13f
                     ? 1.0f
-                    : MathF.Max(1.0f - 0.03f * (totalEncumbrance - 10f), 0.25f); // slope: (1.0 - 0.25) / (35 - 10)
+                    : MathF.Max(1.0f - ((props.ArmorEncumbrance - 13f) / (25f - 13f)) * 0.75f, 0.25f);
 
                 props.ReloadSpeed *= reloadThrustMultiplier;
                 props.ThrustOrRangedReadySpeedMultiplier *= reloadThrustMultiplier;
@@ -525,7 +525,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 if (agent.IsMainAgent)
                 {
                     InformationManager.DisplayMessage(new InformationMessage(
-                        $"[DEBUG] Enc: {totalEncumbrance:F1} | Rld: {props.ReloadSpeed:F2} | Thrust: {props.ThrustOrRangedReadySpeedMultiplier:F2} | Inacc: {props.WeaponInaccuracy:F2}"
+                        $"[DEBUG] Enc: {props.ArmorEncumbrance:F1} | Rld: {props.ReloadSpeed:F2} | Thrust: {props.ThrustOrRangedReadySpeedMultiplier:F2} | Inacc: {props.WeaponInaccuracy:F2}"
                     ));
                 }
             }

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -501,8 +501,6 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 // Mounted skill penalty
                 props.WeaponInaccuracy /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
 
-                // Total encumbrance = armor + weapons
-                float totalEncumbrance = props.ArmorEncumbrance + props.WeaponsEncumbrance;
 
                 // Encumbrance-based inaccuracy penalty (neutral at 20, quadratic growth)
                 float encumbranceRatio = totalEncumbrance / 20.0f;
@@ -523,14 +521,6 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 // Clamp values to ensure gameplay safety
                 props.ReloadSpeed = MathF.Clamp(props.ReloadSpeed, 0.25f, 1.0f);
                 props.ThrustOrRangedReadySpeedMultiplier = MathF.Clamp(props.ThrustOrRangedReadySpeedMultiplier, 0.25f, 1.0f);
-
-                // In-game debug (only for player)
-                if (agent.IsMainAgent)
-                {
-                    InformationManager.DisplayMessage(new InformationMessage(
-                        $"[DEBUG] Enc: {totalEncumbrance:F1} | Rld: {props.ReloadSpeed:F2} | Thrust: {props.ThrustOrRangedReadySpeedMultiplier:F2} | Inacc: {props.WeaponInaccuracy:F2}"
-                    ));
-                }
             }
         }
 

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -501,16 +501,16 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 // Mounted skill penalty
                 props.WeaponInaccuracy /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
 
-                // Encumbrance-based inaccuracy penalty (neutral at 15, quadratic growth)
-                float encumbranceRatio = props.ArmorEncumbrance / 15.0f;
+                // Encumbrance-based inaccuracy penalty (neutral at 13, quadratic growth)
+                float encumbranceRatio = props.ArmorEncumbrance / 13.0f;
                 float encumbranceMultiplier = MathF.Max(
                     1.0f + (MathF.Pow(encumbranceRatio, 2f) - 1.0f) * 0.75f,
                     1.0f);
 
                 props.WeaponInaccuracy *= encumbranceMultiplier;
 
-                // Reload & thrust speed penalty: linearly drops from 1.0 at 15 to 0.25 at 25
-                float reloadThrustMultiplier = props.ArmorEncumbrance <= 15f
+                // Reload & thrust speed penalty: linearly drops from 1.0 at 13 to 0.25 at 23
+                float reloadThrustMultiplier = props.ArmorEncumbrance <= 13f
                     ? 1.0f
                     : MathF.Max(1.0f - ((props.ArmorEncumbrance - 15f) / 10f) * 0.75f, 0.25f);
 

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -481,22 +481,33 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
 
             // Mounted Archery
 
-            if (agent.HasMount)
+            if (agent.HasMount && equippedItem.IsRangedWeapon)
             {
                 int mountedArcherySkill = GetEffectiveSkill(agent, CrpgSkills.MountedArchery);
 
                 float weaponMaxMovementAccuracyPenalty = 0.03f / _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
                 float weaponMaxUnsteadyAccuracyPenalty = 0.15f / _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
+
                 if (equippedItem.RelevantSkill == DefaultSkills.Crossbow)
                 {
-                    weaponMaxUnsteadyAccuracyPenalty /= ImpactOfStrReqOnCrossbows(agent, 0.2f, primaryItem);
-                    weaponMaxMovementAccuracyPenalty /= ImpactOfStrReqOnCrossbows(agent, 0.2f, primaryItem);
+                    float crossbowPenaltyFactor = ImpactOfStrReqOnCrossbows(agent, 0.2f, primaryItem);
+                    weaponMaxUnsteadyAccuracyPenalty /= crossbowPenaltyFactor;
+                    weaponMaxMovementAccuracyPenalty /= crossbowPenaltyFactor;
                 }
 
                 props.WeaponMaxMovementAccuracyPenalty = Math.Min(weaponMaxMovementAccuracyPenalty, 1f);
                 props.WeaponMaxUnsteadyAccuracyPenalty = Math.Min(weaponMaxUnsteadyAccuracyPenalty, 1f);
+
                 props.WeaponInaccuracy /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
-                props.WeaponInaccuracy *= (0.8f + (float)Math.Pow(perceivedWeight / 6.5f, 2f)) / 0.3f;
+                props.ReloadSpeed /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
+                props.ThrustOrRangedReadySpeedMultiplier /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
+
+                float encumbranceRatio = totalEncumbrance / 15.0f;
+                float encumbranceMultiplier = MathF.Max((0.8f + MathF.Pow(encumbranceRatio, 2f)) / 0.3f, 1.0f);
+
+                props.WeaponInaccuracy *= encumbranceMultiplier;
+                props.ReloadSpeed *= encumbranceMultiplier;
+                props.ThrustOrRangedReadySpeedMultiplier *= encumbranceMultiplier;
             }
         }
 

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -481,7 +481,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
 
             // Mounted Archery
 
-            if (agent.HasMount && equippedItem.IsRangedWeapon)
+            if (agent.HasMount)
             {
                 int mountedArcherySkill = GetEffectiveSkill(agent, CrpgSkills.MountedArchery);
 
@@ -498,16 +498,16 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 props.WeaponMaxMovementAccuracyPenalty = Math.Min(weaponMaxMovementAccuracyPenalty, 1f);
                 props.WeaponMaxUnsteadyAccuracyPenalty = Math.Min(weaponMaxUnsteadyAccuracyPenalty, 1f);
 
+                // Mounted skill penalty
                 props.WeaponInaccuracy /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
-                props.ReloadSpeed /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
-                props.ThrustOrRangedReadySpeedMultiplier /= _constants.MountedRangedSkillInaccuracy[mountedArcherySkill];
 
-                float encumbranceRatio = totalEncumbrance / 15.0f;
-                float encumbranceMultiplier = MathF.Max((0.8f + MathF.Pow(encumbranceRatio, 2f)) / 0.3f, 1.0f);
+                // Encumbrance-based penalty
+                float encumbranceRatio = totalEncumbrance / 10.0f;
+                float encumbranceMultiplier = MathF.Max(
+                    1.0f + (MathF.Pow(encumbranceRatio, 2f) - 1.0f) * 2.5f,
+                    1.0f);
 
                 props.WeaponInaccuracy *= encumbranceMultiplier;
-                props.ReloadSpeed *= encumbranceMultiplier;
-                props.ThrustOrRangedReadySpeedMultiplier *= encumbranceMultiplier;
             }
         }
 


### PR DESCRIPTION
Perceived weight impacting inaccuracy was not sufficient, and could not be sufficient on its own at any value, to remove the ability for HA to pump STR, equip high armour and harass infantry in CQC.

This PR changes the perceived weight impacting inaccuracy to:

- Total weight, removing the role of STR at all
- Adds similar effects to lower reload speed and draw speed