### PR TITLE
Removed cavalry breaker and normalised damage to mounts

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -126,25 +126,17 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             }
         }
 
-        // We want to decrease survivability of horses against melee weapon and especially against spears and pikes.
-        // By doing that we ensure that cavalry stays an archer predator while punishing cav errors like running into a wall or an obstacle
-        if (!attackInformation.IsVictimAgentHuman
-            && !attackInformation.DoesAttackerHaveMountAgent
-            && !weapon.CurrentUsageItem.IsConsumable
-            && weapon.CurrentUsageItem.IsMeleeWeapon
-            && !weapon.IsAnyConsumable())
+        // Horse HP and eHP is currently good. To adjust their performance, adjust global melee damage and global non-mounted ranged damage. Mounted ranged damage is not increase to help cavalry attack HA
+        if (!attackInformation.IsVictimAgentHuman && weapon.CurrentUsageItem.IsMeleeWeapon)
         {
-            if (
-                collisionData.StrikeType == (int)StrikeType.Thrust
-                && collisionData.DamageType == (int)DamageTypes.Pierce
-                && weapon.CurrentUsageItem.IsPolearm)
-            {
-                finalDamage *= 1.85f;
-            }
-            else
-            {
-                finalDamage *= 1.4f;
-            }
+            finalDamage *= 1.4f;
+        }
+
+        if (!attackInformation.IsVictimAgentHuman
+            && weapon.CurrentUsageItem.IsRangedWeapon
+            && !attackInformation.DoesAttackerHaveMountAgent)
+        {
+            finalDamage *= 1.3f;
         }
 
         // For bashes (with and without shield) - Not for allies cause teamdmg might reduce the "finalDamage" below zero. That will break teamhits with bashes.


### PR DESCRIPTION
Normalised the damage done to mounts across all melee weapons, whether mounted or not, and all ranged weapons when on foot. This:

- Increases the threat ranged can pose to cavalry, offset by mount armour
- Decreases the large spike in damage mounts might receive from infantry polearm pierce thrusts
- Incentivises cavalry to hunt other cavalry by making their damage more impactful

To go with cavalry refund: https://github.com/crpg2/itembalancing/pull/638