### PR TITLE
Throwing overhaul

### DIFF
--- a/src/Application/Characters/Commands/UpdateCharacterCharacteristicsCommand.cs
+++ b/src/Application/Characters/Commands/UpdateCharacterCharacteristicsCommand.cs
@@ -161,7 +161,7 @@ public record UpdateCharacterCharacteristicsCommand : IMediatorRequest<Character
             return stats.Skills.IronFlesh <= stats.Attributes.Strength / 3
                    && stats.Skills.PowerStrike <= stats.Attributes.Strength / 3
                    && stats.Skills.PowerDraw <= stats.Attributes.Strength / 3
-                   && stats.Skills.PowerThrow <= stats.Attributes.Strength / 3
+                   && stats.Skills.PowerThrow <= stats.Attributes.Strength / 6
                    && stats.Skills.Athletics <= stats.Attributes.Agility / 3
                    && stats.Skills.Riding <= stats.Attributes.Agility / 3
                    && stats.Skills.WeaponMaster <= stats.Attributes.Agility / 3

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -434,7 +434,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                     props.CombatMaxSpeedMultiplier *= 0.75f; // this is slowdown when ready to throw. Higher is better , do not go above 1.0
 
                     // These do not matter if props.WeaponMaxUnsteadyAccuracyPenalty is set to 0f
-                    props.WeaponUnsteadyBeginTime = 1.0f + weaponSkill * 0.006f + powerThrow * powerThrow / 10f * 0.4f; // Time at which your character becomes tired and the accuracy declines
+                    props.WeaponUnsteadyBeginTime = 1.0f + weaponSkill * 0.006f + powerThrow * powerThrow / 10f * 1.6f; // Time at which your character becomes tired and the accuracy declines
                     props.WeaponUnsteadyEndTime = 10f + props.WeaponUnsteadyBeginTime; // time at which your character is completely tired.
                 }
 

--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -88,10 +88,10 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
             WeaponClass.Crossbow => 0.5f,
             WeaponClass.Musket => 0.5f,
             WeaponClass.Pistol => 0.5f,
-            WeaponClass.Stone => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1f,
-            WeaponClass.ThrowingAxe => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForSwingThrowing / 30f, 2f) * 1.65f,
-            WeaponClass.ThrowingKnife => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.65f,
-            WeaponClass.Javelin => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.65f,
+            WeaponClass.Stone => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.0f,
+            WeaponClass.ThrowingAxe => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForSwingThrowing / 30f, 2f) * 1.2f,
+            WeaponClass.ThrowingKnife => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.2f,
+            WeaponClass.Javelin => (float)Math.Pow(weapon.ThrustDamage * damageTypeFactorForThrustThrowing / 30f, 2f) * 1.2f,
             _ => 1f,
         };
 
@@ -416,22 +416,22 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                 {
                     int powerThrow = GetEffectiveSkill(agent, CrpgSkills.PowerThrow);
 
-                    float wpfImpactOnWindUp = 180f; // lower is better 160f
+                    float wpfImpactOnWindUp = 100f; // lower is better 160f
                     float wpfImpactOnReloadSpeed = 240f; // lower is better 200f
 
                     float DamageImpactOnWindUp = equippedItem.ThrustDamage * CrpgItemValueModel.CalculateDamageTypeFactorForThrown(equippedItem.ThrustDamageType) / CrpgItemValueModel.CalculateDamageTypeFactorForThrown(DamageTypes.Cut);
 
                     props.WeaponMaxUnsteadyAccuracyPenalty = 0.0035f;
-                    props.WeaponMaxMovementAccuracyPenalty = 0.0010f;
+                    props.WeaponMaxMovementAccuracyPenalty = 0.15f;
 
-                    props.WeaponRotationalAccuracyPenaltyInRadians = 0.025f; // this is accuracy loss when turning lower is better
+                    props.WeaponRotationalAccuracyPenaltyInRadians = 0.15f; // this is accuracy loss when turning lower is better
 
                     props.WeaponBestAccuracyWaitTime = 0.00001f; // set to extremely low because as soon as windup is finished , thrower is accurate
 
-                    props.ThrustOrRangedReadySpeedMultiplier = MBMath.Lerp(0.2f, 0.3f, (float)Math.Pow(itemSkill / wpfImpactOnWindUp, 3f) * 40f / DamageImpactOnWindUp); // WindupSpeed
-                    props.ReloadSpeed *= MBMath.Lerp(0.6f, 1.4f, itemSkill / wpfImpactOnReloadSpeed); // this only affect picking a new axe
+                    props.ThrustOrRangedReadySpeedMultiplier = MBMath.Lerp(0.25f, 0.25f, (float)Math.Pow(itemSkill / wpfImpactOnWindUp, 3f) * 40f / DamageImpactOnWindUp); // WindupSpeed
+                    props.ReloadSpeed *= MBMath.Lerp(0.8f, 1.0f, itemSkill / wpfImpactOnReloadSpeed); // this only affect picking a new throwing weapon
 
-                    props.CombatMaxSpeedMultiplier *= 0.85f; // this is slowdown when ready to throw. Higher is better , do not go above 1.0
+                    props.CombatMaxSpeedMultiplier *= 0.75f; // this is slowdown when ready to throw. Higher is better , do not go above 1.0
 
                     // These do not matter if props.WeaponMaxUnsteadyAccuracyPenalty is set to 0f
                     props.WeaponUnsteadyBeginTime = 1.0f + weaponSkill * 0.006f + powerThrow * powerThrow / 10f * 0.4f; // Time at which your character becomes tired and the accuracy declines

--- a/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
+++ b/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
@@ -115,11 +115,11 @@ internal class CrpgStrikeMagnitudeModel : MultiplayerStrikeMagnitudeModel
             WeaponClass.Arrow => 1.2f,
             WeaponClass.Bolt => 0.9f,
             WeaponClass.Cartridge => 0.8f,
-            WeaponClass.Stone => 0.95f,
+            WeaponClass.Stone => 1.2f,
             WeaponClass.Boulder => 0.9f,
-            WeaponClass.ThrowingAxe => 1.3f,
-            WeaponClass.ThrowingKnife => 1.2f,
-            WeaponClass.Javelin => 1.1f,
+            WeaponClass.ThrowingAxe => 1.0f,
+            WeaponClass.ThrowingKnife => 1.0f,
+            WeaponClass.Javelin => 1.0f,
             _ => 1f,
         };
     }

--- a/src/WebUI/locales/en.yml
+++ b/src/WebUI/locales/en.yml
@@ -497,6 +497,7 @@ character:
       linked:
         oneAttrs: 1 attributes
         threeStr: 3 strength per level
+        sixStr: 6 strength per level
         threeAgi: 3 agility per level
         sixAgi: 6 agility per level
 
@@ -530,7 +531,7 @@ character:
         powerThrow:
           title: Power throw
           desc: Increases damage by {value} and your steadiness with throwing weapons
-          requires: '@:character.characteristic.requires.linked.threeStr'
+          requires: '@:character.characteristic.requires.linked.sixStr'
         athletics:
           title: Athletics
           desc: Increases your maximum running speed and decreases the time to reach it

--- a/src/WebUI/locales/ru.yml
+++ b/src/WebUI/locales/ru.yml
@@ -459,6 +459,7 @@ character:
       linked:
         oneAttrs: 1 очко атрибутов
         threeStr: 3 очка силы за каждый уровень
+        sixStr: 6 очков силы за каждый уровень
         threeAgi: 3 очка ловкости за каждый уровень
         sixAgi: 6 очков ловкости за каждый уровень
 
@@ -492,7 +493,7 @@ character:
         powerThrow:
           title: Мощный бросок
           desc: Увеличивает урон от метательного оружия на {value}
-          requires: '@:character.characteristic.requires.linked.threeStr'
+          requires: '@:character.characteristic.requires.linked.sixStr'
         athletics:
           title: Атлетика
           desc: Увеличивает вашу максимальную скорость бега и уменьшает время ее достижения

--- a/src/WebUI/src/composables/character/use-character-characteristic.ts
+++ b/src/WebUI/src/composables/character/use-character-characteristic.ts
@@ -135,7 +135,6 @@ const skillRequirementsSatisfied = (
     case 'ironFlesh':
     case 'powerStrike':
     case 'powerDraw':
-    case 'powerThrow':
       return skill <= Math.floor(characteristics.attributes.strength / 3) // TODO: move "3" to constants.json
 
     case 'athletics':
@@ -145,7 +144,10 @@ const skillRequirementsSatisfied = (
 
     case 'mountedArchery':
     case 'shield':
-      return skill <= Math.floor(characteristics.attributes.agility / 6)
+          return skill <= Math.floor(characteristics.attributes.agility / 6)
+
+      case 'powerThrow':
+          return skill <= Math.floor(characteristics.attributes.strength / 6)
 
     /* c8 ignore next 2 */
     default:

--- a/src/WebUI/src/composables/character/use-character-characteristic.ts
+++ b/src/WebUI/src/composables/character/use-character-characteristic.ts
@@ -137,6 +137,9 @@ const skillRequirementsSatisfied = (
     case 'powerDraw':
       return skill <= Math.floor(characteristics.attributes.strength / 3) // TODO: move "3" to constants.json
 
+    case 'powerThrow':
+      return skill <= Math.floor(characteristics.attributes.strength / 6)
+
     case 'athletics':
     case 'riding':
     case 'weaponMaster':
@@ -144,10 +147,7 @@ const skillRequirementsSatisfied = (
 
     case 'mountedArchery':
     case 'shield':
-          return skill <= Math.floor(characteristics.attributes.agility / 6)
-
-      case 'powerThrow':
-          return skill <= Math.floor(characteristics.attributes.strength / 6)
+      return skill <= Math.floor(characteristics.attributes.agility / 6)
 
     /* c8 ignore next 2 */
     default:
@@ -217,21 +217,21 @@ export const useCharacterCharacteristic = (
     const oldCharacteristicValue = characteristicSection[characteristicKey]
 
     const costToIncrease
-      = characteristicCost(characteristicSectionKey, characteristicKey, oldCharacteristicValue)
-      - characteristicCost(characteristicSectionKey, characteristicKey, newCharacteristicValue)
+            = characteristicCost(characteristicSectionKey, characteristicKey, oldCharacteristicValue)
+              - characteristicCost(characteristicSectionKey, characteristicKey, newCharacteristicValue)
 
     characteristicDeltaSection.points += costToIncrease
 
     characteristicDeltaSection[characteristicKey]
-      = newCharacteristicValue - characteristicInitialSection[characteristicKey]
+            = newCharacteristicValue - characteristicInitialSection[characteristicKey]
 
     if (characteristicKey === 'agility') {
       characteristicsDelta.value.weaponProficiencies.points
-        += wppForAgility(newCharacteristicValue) - wppForAgility(oldCharacteristicValue)
+                += wppForAgility(newCharacteristicValue) - wppForAgility(oldCharacteristicValue)
     }
     else if (characteristicKey === 'weaponMaster') {
       characteristicsDelta.value.weaponProficiencies.points
-        += wppForWeaponMaster(newCharacteristicValue) - wppForWeaponMaster(oldCharacteristicValue)
+                += wppForWeaponMaster(newCharacteristicValue) - wppForWeaponMaster(oldCharacteristicValue)
     }
   }
 
@@ -271,8 +271,8 @@ export const useCharacterCharacteristic = (
     const points = characteristics.value[characteristicSectionKey].points
 
     const costToIncrease
-      = characteristicCost(characteristicSectionKey, characteristicKey, value + 1)
-      - characteristicCost(characteristicSectionKey, characteristicKey, value)
+            = characteristicCost(characteristicSectionKey, characteristicKey, value + 1)
+              - characteristicCost(characteristicSectionKey, characteristicKey, value)
 
     const requirementsSatisfied = characteristicRequirementsSatisfied(
       characteristicSectionKey,

--- a/test/Application.UTest/Characters/UpdateCharacterCharacteristicsCommandTest.cs
+++ b/test/Application.UTest/Characters/UpdateCharacterCharacteristicsCommandTest.cs
@@ -76,7 +76,7 @@ public class UpdateCharacterCharacteristicsCommandTest : TestBase
                     IronFlesh = 10,
                     PowerStrike = 10,
                     PowerDraw = 10,
-                    PowerThrow = 10,
+                    PowerThrow = 5,
                     Athletics = 10,
                     Riding = 10,
                     WeaponMaster = 10,
@@ -99,11 +99,11 @@ public class UpdateCharacterCharacteristicsCommandTest : TestBase
         Assert.That(stats.Attributes.Points, Is.EqualTo(0));
         Assert.That(stats.Attributes.Strength, Is.EqualTo(30));
         Assert.That(stats.Attributes.Agility, Is.EqualTo(60));
-        Assert.That(stats.Skills.Points, Is.EqualTo(0));
+        Assert.That(stats.Skills.Points, Is.EqualTo(5));
         Assert.That(stats.Skills.IronFlesh, Is.EqualTo(10));
         Assert.That(stats.Skills.PowerStrike, Is.EqualTo(10));
         Assert.That(stats.Skills.PowerDraw, Is.EqualTo(10));
-        Assert.That(stats.Skills.PowerThrow, Is.EqualTo(10));
+        Assert.That(stats.Skills.PowerThrow, Is.EqualTo(5));
         Assert.That(stats.Skills.Athletics, Is.EqualTo(10));
         Assert.That(stats.Skills.Riding, Is.EqualTo(10));
         Assert.That(stats.Skills.WeaponMaster, Is.EqualTo(10));


### PR DESCRIPTION
**Throwing**
- Decreased the impact of damage on throwing weapon accuracy (apart from stones)
- Increased the impact of WPF on wind up speed
- Increased the maximum penalty for movement
- Increased the maximum penalty for rotation
- Increased the minimum and decreased the maximum wind up speed
- Increased the minimum and decreased the maximum reload speed
- Decreased the combat speed multiplier

**Armour pen (increasing is worse)**
- Increased stones to 1.2f
- Decreased all other throwing weapons to 1.0f

**Skills**
- WIP Power throw is now every 6STR instead of 3STR, no change to % increase in damage

Needs https://github.com/crpg2/itembalancing/pull/641