### PR TITLE
Capsule increase step 1

### DIFF
--- a/src/Module.Server/ModuleData/native_parameters.xml
+++ b/src/Module.Server/ModuleData/native_parameters.xml
@@ -14,7 +14,7 @@
     <native_parameter id="running_backward_speed_multiplier" value="0.50" />  <!-- Native = 0.5 -->
     <native_parameter id="running_sides_speed_multiplier" value="0.65" />   <!-- Native = 0.65-->
     <native_parameter id="ladder_climb_up_speed_multiplier"  value="0.88" /> <!-- Native = 0.68-->
-    <native_parameter id="humanoid_physics_capsule_radius_multiplier_for_friend" value="1.525" /> <!--Native = 0.95-->
+    <native_parameter id="humanoid_physics_capsule_radius_multiplier_for_friend" value="1.475" /> <!--Native = 0.95-->
     <native_parameter	id="humanoid_physics_capsule_radius_multiplier_for_enemy"	value="1.875" /> <!--Native = 1.5-->
     <native_parameter id="smaller_humanoid_physics_capsule_radius_multiplier_for_static_bodies" value="0.815" /> <!--Environment (trees/walls, any entities) Native = 0.67-->
   </native_parameters>


### PR DESCRIPTION
Justification ripped from AppleTruce below. Basically incremental steps back to Native capsules on live.

"As of PR #304, we have 

src/Module.Server/ModuleData/monsters.xml
<Capsules>
      <body_capsule
                radius="0.27"
                pos1="0.0, 0.0, 1.55"
                pos2="0.0, 0, 0.8" />
      <crouched_body_capsule
                radius="0.27"
                pos1="0.0, 0.0, 1.55"
                pos2="0.0, 0, 0.6" />
    </Capsules>

src/Module.Server/ModuleData/native_parameters.xml
 <native_parameter id="humanoid_physics_capsule_radius_multiplier_for_friend" value="1.5" /> <!--Native = 0.95-->
    <native_parameter    id="humanoid_physics_capsule_radius_multiplier_for_enemy"    value="1.85" /> <!--Native = 1.5-->
    <native_parameter id="smaller_humanoid_physics_capsule_radius_multiplier_for_static_bodies" value="0.8" /> <!--Environment (trees/walls, any entities) Native = 0.67→

This results in current capsule calculations:
Ally:        0.27(1.5)= 0.405
Enemy:    0.27(1.85)=0.4995
Scene:        0.27(0.8)=0.216

The native calculations are:
Ally:        0.37(0.95)= 0.3515
Enemy:    0.37(1.5)=0.555
Scene:        0.37(0.67)=0.2479 



In my opinion, we should look into increasing the enemy capsule from 0.4995 to 0.555 or at least closer to 0.555 than it is now.  This I think would improve glancing, but also reduce people being able to run through you or swing inside of your mesh without collision being detected, which is something personally I’m not a fan of.I also think increasing the interaction with scene objects could prevent people hiding their hitboxes in walls, ala HMB str archer strat and people getting stuck in maps in general 
So I think to safely increment we split it into like 6-8 patches.  Where we increase  <native_parameter    id="humanoid_physics_capsule_radius_multiplier_for_enemy"    value="1.85" /> <!--Native = 1.5– value from 1.85 to 2.055 an overall increase of 0.206 by ~.025 per patch over the course of 8 patches.  I believe that would give us plenty of time to revert if issues started happening after one of these incremental increases.
For static bodies I would propose we increase id="smaller_humanoid_physics_capsule_radius_multiplier_for_static_bodies" value="0.8" /> <!--Environment (trees/walls, any entities) Native = 0.67→ from 0.8 to 0.92 an overall increase of  over the course of 0.12 by ~.015 per patch over the course of 8 patches
cRPG effective capsule is bigger than native. In a twist this may actually be contributing to excessive team wounding when fighting close with allys like in shield wall. It could be worth targeting a native value there as well which would be a reduction of the current 1.5 value by .025 per patch to 1.3 final value."