### PR TITLE
mod: Friendly fire reporting

### DIFF
--- a/src/Module.Client/Module.Client.csproj
+++ b/src/Module.Client/Module.Client.csproj
@@ -58,6 +58,7 @@
     <Compile Remove="..\Module.Server\Common\CrpgCustomBannerServer.cs" />
     <Compile Remove="..\Module.Server\HarmonyPatches\MissionNetworkComponentPatch.cs" />
     <Compile Remove="..\Module.Server\HarmonyPatches\SendPeerInformationsToPeerPatch.cs" />
+    <Compile Remove="..\Module.Server\Common\FriendlyFireReport\FriendlyFireReportServerBehavior.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Module.Editor/Module.Editor.csproj
+++ b/src/Module.Editor/Module.Editor.csproj
@@ -66,6 +66,8 @@
     <Compile Remove="..\Module.Server\Common\CrpgCustomBannerServer.cs" />
     <Compile Remove="..\Module.Server\HarmonyPatches\MissionNetworkComponentPatch.cs" />
     <Compile Remove="..\Module.Server\HarmonyPatches\SendPeerInformationsToPeerPatch.cs" />
+    <Compile Remove="..\Module.Server\Common\FriendlyFireReport\FriendlyFireReportServerBehavior.cs" />
+    <Compile Remove="..\Module.Server\Common\FriendlyFireReport\FriendlyFireReportClientBehavior.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Module.Server/Api/Models/ActivityLogs/CrpgActivityLogType.cs
+++ b/src/Module.Server/Api/Models/ActivityLogs/CrpgActivityLogType.cs
@@ -5,4 +5,6 @@ internal enum CrpgActivityLogType
     ServerJoined,
     ChatMessageSent,
     TeamHit,
+    TeamHitReported,
+    TeamHitReportedUserKicked,
 }

--- a/src/Module.Server/Common/ChatCommands/Admin/FriendlyFireInfoCommand.cs
+++ b/src/Module.Server/Common/ChatCommands/Admin/FriendlyFireInfoCommand.cs
@@ -1,0 +1,63 @@
+using Crpg.Module.Common.FriendlyFireReport;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.Common.ChatCommands.Admin;
+
+internal class FriendlyFireInfoCommand : AdminCommand
+{
+    public FriendlyFireInfoCommand(ChatCommandsComponent chatComponent)
+    : base(chatComponent)
+    {
+        Name = "ff";
+        Description = $"'{ChatCommandsComponent.CommandPrefix}{Name} PLAYERID or PLAYERNANE' to get friendly fire information for player.";
+        Overloads = new CommandOverload[]
+        {
+            new(new[] { ChatCommandParameterType.PlayerId }, ExecuteFriendlyFireInfoByNetworkPeer),
+            new(new[] { ChatCommandParameterType.String }, ExecuteFriendlyFireInfoByName),
+        };
+    }
+
+    private void ExecuteFriendlyFireInfoByName(NetworkCommunicator fromPeer, object[] arguments)
+    {
+        string targetName = (string)arguments[0];
+        if (!TryGetPlayerByName(fromPeer, targetName, out var targetPeer))
+        {
+            return;
+        }
+
+        arguments = new object[] { targetPeer! };
+        ExecuteFriendlyFireInfoByNetworkPeer(fromPeer, arguments);
+    }
+
+    private void ExecuteFriendlyFireInfoByNetworkPeer(NetworkCommunicator fromPeer, object[] arguments)
+    {
+        var targetPeer = (NetworkCommunicator)arguments[0];
+        var behavior = Mission.Current.GetMissionBehavior<FriendlyFireReportServerBehavior>();
+
+        if (behavior == null)
+        {
+            ChatComponent.ServerSendMessageToPlayer(fromPeer, ColorFatal, "FriendlyFireReportServerBehavior not found!");
+            return;
+        }
+
+        if (!CrpgServerConfiguration.IsFriendlyFireReportEnabled)
+        {
+            ChatComponent.ServerSendMessageToPlayer(fromPeer, ColorWarning, "[FF] Reporting teamhits is disabled.");
+        }
+
+        if (targetPeer == null || !targetPeer.IsConnectionActive)
+        {
+            ChatComponent.ServerSendMessageToPlayer(fromPeer, ColorWarning, $"Invalid peer: {arguments}");
+            return;
+        }
+
+        var (activeReported, decayedReported, notReported) = behavior.GetReportedTeamHitBreakdown(targetPeer);
+
+        int active = activeReported;
+        int decayed = decayedReported;
+        int not = notReported;
+
+        string strOut = $"[FF] Info for {targetPeer.UserName}: Active={active}, Decayed={decayed}, NotReported={not}, Combined={active + decayed + not}";
+        ChatComponent.ServerSendMessageToPlayer(fromPeer, ColorSuccess, strOut);
+    }
+}

--- a/src/Module.Server/Common/ChatCommands/ChatCommandsComponent.cs
+++ b/src/Module.Server/Common/ChatCommands/ChatCommandsComponent.cs
@@ -47,6 +47,7 @@ internal class ChatCommandsComponent : GameHandler
                 new HotConstantUpdateCommand(this),
                 new OrderCommand(this),
                 new HelpCommand(this),
+                new FriendlyFireInfoCommand(this),
         };
 #else
         _commands = Array.Empty<ChatCommand>();

--- a/src/Module.Server/Common/CrpgActivityLogsBehavior.cs
+++ b/src/Module.Server/Common/CrpgActivityLogsBehavior.cs
@@ -72,6 +72,16 @@ internal class CrpgActivityLogsBehavior : MissionLogic
         }
     }
 
+    public void AddTeamHitReportedLogWrapper(int userId, int targetUserId, int reportedHits, int decayedHits, int unreportedHits, int onReporterHits, int damage, string weaponName)
+    {
+        AddTeamHitReportedLog(userId, targetUserId, reportedHits, decayedHits, unreportedHits, onReporterHits, damage, weaponName);
+    }
+
+    public void AddTeamHitReportedUserKickedLogWrapper(int userId, int reportedHits, int decayedHits, int unreportedHits)
+    {
+        AddTeamHitReportedUserKickedLog(userId, reportedHits, decayedHits, unreportedHits);
+    }
+
     private void OnMessageReceivedAtDedicatedServer(NetworkCommunicator fromPeer, string message)
     {
         int? userId = fromPeer.GetComponent<CrpgPeer>()?.User?.Id;
@@ -103,6 +113,30 @@ internal class CrpgActivityLogsBehavior : MissionLogic
         {
             ["targetUserId"] = targetUserId.ToString(),
             ["damage"] = damage.ToString(),
+        });
+    }
+
+    private void AddTeamHitReportedLog(int userId, int targetUserId, int reportedHits, int decayedHits, int unreportedHits, int onReporterHits, int damage, string weaponName)
+    {
+        AddLog(CrpgActivityLogType.TeamHitReported, userId, new Dictionary<string, string>
+        {
+            ["targetUserId"] = targetUserId.ToString(),
+            ["reportedHits"] = reportedHits.ToString(),
+            ["decayedHits"] = decayedHits.ToString(),
+            ["unreportedHits"] = unreportedHits.ToString(),
+            ["onReporterHits"] = onReporterHits.ToString(),
+            ["damage"] = damage.ToString(),
+            ["weapon"] = weaponName,
+        });
+    }
+
+    private void AddTeamHitReportedUserKickedLog(int userId, int reportedHits, int decayedHits, int unreportedHits)
+    {
+        AddLog(CrpgActivityLogType.TeamHitReportedUserKicked, userId, new Dictionary<string, string>
+        {
+            ["reportedHits"] = reportedHits.ToString(),
+            ["decayedHits"] = decayedHits.ToString(),
+            ["unreportedHits"] = unreportedHits.ToString(),
         });
     }
 

--- a/src/Module.Server/Common/CrpgServerConfiguration.cs
+++ b/src/Module.Server/Common/CrpgServerConfiguration.cs
@@ -33,6 +33,12 @@ internal static class CrpgServerConfiguration
     public static int ControlledBotsCount { get; private set; } = 0;
     public static int BaseNakedEquipmentValue { get; private set; } = 10000;
     public static Tuple<TimeSpan, TimeSpan, TimeZoneInfo>? HappyHours { get; private set; }
+    public static bool IsFriendlyFireReportEnabled { get; private set; } = true;
+    public static int FriendlyFireReportMaxHits { get; private set; } = 5;
+    public static bool IsFriendlyFireReportNotifyAdminsEnabled { get; private set; } = true;
+    public static int FriendlyFireReportDecaySeconds { get; private set; } = 60;
+    public static int FriendlyFireReportWindowSeconds { get; private set; } = 10;
+    public static bool IsFriendlyFireReportDecayOnRoundStartEnabled { get; private set; } = true;
 
     [UsedImplicitly]
     [ConsoleCommandMethod("crpg_team_balancer_clan_group_size_penalty", "Apply a rating increase to members of the same clan that are playing in the same team")]
@@ -171,5 +177,101 @@ internal static class CrpgServerConfiguration
     private static void ApplyHarmonyPatches()
     {
         BannerlordPatches.Apply();
+    }
+
+    [UsedImplicitly]
+    [ConsoleCommandMethod("crpg_ff_report_enabled", "Report friendly fire by pressing Ctrl+M")]
+    private static void SetFriendlyFireReportEnabled(string? inputStr)
+    {
+        if (inputStr == null
+            || !bool.TryParse(inputStr, out bool outputBool))
+        {
+            Debug.Print($"Invalid friendly fire report Enabled/Disabled setting: {inputStr} - must be true or false");
+            return;
+        }
+
+        IsFriendlyFireReportEnabled = outputBool;
+        Debug.Print($"--Changed: crpg_ff_report_enabled to: {outputBool}");
+    }
+
+    [UsedImplicitly]
+    [ConsoleCommandMethod("crpg_ff_report_max_hit_count", "Friendly fire report, max hits before kick")]
+    private static void SetFriendlyFireReportMaxHits(string? inputStr)
+    {
+        if (inputStr == null
+            || !int.TryParse(inputStr, out int outputInt)
+            || outputInt < 1
+            || outputInt > 10)
+        {
+            Debug.Print($"Invalid friendly fire report Max Hit Count setting: {inputStr} - must be an int between 1 and 10");
+            return;
+        }
+
+        FriendlyFireReportMaxHits = outputInt;
+        Debug.Print($"--Changed crpg_ff_report_max_hit_count to: {outputInt}");
+    }
+
+    [UsedImplicitly]
+    [ConsoleCommandMethod("crpg_ff_report_notify_admins", "Friendly fire report, notify admins")]
+    private static void SetControlMReportNotifyAdmins(string? inputStr)
+    {
+        if (inputStr == null
+            || !bool.TryParse(inputStr, out bool outputBool))
+        {
+            Debug.Print($"Invalid friendly fire report Notify Admins setting: {inputStr} - must be true or false");
+            return;
+        }
+
+        IsFriendlyFireReportNotifyAdminsEnabled = outputBool;
+        Debug.Print($"--Changed crpg_ff_report_notify_admins to: {outputBool}");
+    }
+
+    [UsedImplicitly]
+    [ConsoleCommandMethod("crpg_ff_report_decay_seconds", "Friendly fire report, decay time of a reported teamhit")]
+    private static void SetFriendlyFireReportDecaySeconds(string? inputStr)
+    {
+        if (inputStr == null
+            || !int.TryParse(inputStr, out int outputInt)
+            || outputInt < 0
+            || outputInt > 200)
+        {
+            Debug.Print($"Invalid friendly fire report decay seconds setting: {inputStr} - must be integer between 0 and 200");
+            return;
+        }
+
+        FriendlyFireReportDecaySeconds = outputInt;
+        Debug.Print($"--Changed crpg_ff_report_decay_seconds to: {outputInt}");
+    }
+
+    [UsedImplicitly]
+    [ConsoleCommandMethod("crpg_ff_report_window_seconds", "Friendly fire report, window of time to report a teamhit")]
+    private static void SetFriendlyFireReportWindowSeconds(string? inputStr)
+    {
+        if (inputStr == null
+            || !int.TryParse(inputStr, out int outputInt)
+            || outputInt < 0
+            || outputInt > 200)
+        {
+            Debug.Print($"Invalid friendly fire report window seconds setting: {inputStr} - must be integer between 0 and 200");
+            return;
+        }
+
+        FriendlyFireReportWindowSeconds = outputInt;
+        Debug.Print($"--Changed crpg_ff_report_window_seconds to: {outputInt}");
+    }
+
+    [UsedImplicitly]
+    [ConsoleCommandMethod("crpg_ff_report_decay_on_round_start", "Friendly fire report, decay all hits on round start")]
+    private static void SetFriendlyFireDecayOnRoundStart(string? inputStr)
+    {
+        if (inputStr == null
+             || !bool.TryParse(inputStr, out bool outputBool))
+        {
+            Debug.Print($"Invalid friendly fire report decay on round start setting: {inputStr} - must be true or false");
+            return;
+        }
+
+        IsFriendlyFireReportDecayOnRoundStartEnabled = outputBool;
+        Debug.Print($"--Changed crpg_ff_report_decay_on_round_start to: {outputBool}");
     }
 }

--- a/src/Module.Server/Common/CrpgServerConfiguration.cs
+++ b/src/Module.Server/Common/CrpgServerConfiguration.cs
@@ -187,6 +187,7 @@ internal static class CrpgServerConfiguration
             || !bool.TryParse(inputStr, out bool outputBool))
         {
             Debug.Print($"Invalid friendly fire report Enabled/Disabled setting: {inputStr} - must be true or false");
+            Debug.Print($"Current value: crpg_ff_report_enabled {IsFriendlyFireReportEnabled}");
             return;
         }
 
@@ -204,6 +205,7 @@ internal static class CrpgServerConfiguration
             || outputInt > 10)
         {
             Debug.Print($"Invalid friendly fire report Max Hit Count setting: {inputStr} - must be an int between 1 and 10");
+            Debug.Print($"Current value: crpg_ff_report_max_hit_count {FriendlyFireReportMaxHits}");
             return;
         }
 
@@ -219,6 +221,7 @@ internal static class CrpgServerConfiguration
             || !bool.TryParse(inputStr, out bool outputBool))
         {
             Debug.Print($"Invalid friendly fire report Notify Admins setting: {inputStr} - must be true or false");
+            Debug.Print($"Current value: crpg_ff_report_notify_admins {IsFriendlyFireReportNotifyAdminsEnabled}");
             return;
         }
 
@@ -236,6 +239,7 @@ internal static class CrpgServerConfiguration
             || outputInt > 200)
         {
             Debug.Print($"Invalid friendly fire report decay seconds setting: {inputStr} - must be integer between 0 and 200");
+            Debug.Print($"Current value: crpg_ff_report_decay_seconds {FriendlyFireReportDecaySeconds}");
             return;
         }
 
@@ -253,6 +257,7 @@ internal static class CrpgServerConfiguration
             || outputInt > 200)
         {
             Debug.Print($"Invalid friendly fire report window seconds setting: {inputStr} - must be integer between 0 and 200");
+            Debug.Print($"Current value: crpg_ff_report_window_seconds {FriendlyFireReportWindowSeconds}");
             return;
         }
 
@@ -268,6 +273,7 @@ internal static class CrpgServerConfiguration
              || !bool.TryParse(inputStr, out bool outputBool))
         {
             Debug.Print($"Invalid friendly fire report decay on round start setting: {inputStr} - must be true or false");
+            Debug.Print($"Current value: crpg_ff_report_decay_on_round_start {IsFriendlyFireReportDecayOnRoundStartEnabled}");
             return;
         }
 

--- a/src/Module.Server/Common/FriendlyFireReport/FriendlyFireHitMessage.cs
+++ b/src/Module.Server/Common/FriendlyFireReport/FriendlyFireHitMessage.cs
@@ -1,0 +1,51 @@
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Crpg.Module.Common.FriendlyFireReport;
+
+[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+internal sealed class FriendlyFireHitMessage : GameNetworkMessage
+{
+    public int AttackerAgentIndex { get; private set; }
+    public int Damage { get; private set; }
+    public int ReportWindow { get; private set; }
+    private readonly CompressionInfo.Integer reportWindowCompressionInfo = new(0, 200, true);
+
+    public FriendlyFireHitMessage()
+    {
+        // Default constructor for deserialization
+    }
+
+    public FriendlyFireHitMessage(int attackerAgentIndex, int damage, int reportWindow)
+    {
+        AttackerAgentIndex = attackerAgentIndex;
+        Damage = damage;
+        ReportWindow = reportWindow;
+    }
+
+    protected override bool OnRead()
+    {
+        bool bufferReadValid = true;
+        AttackerAgentIndex = GameNetworkMessage.ReadAgentIndexFromPacket(ref bufferReadValid);
+        Damage = GameNetworkMessage.ReadIntFromPacket(CompressionBasic.AgentHitDamageCompressionInfo, ref bufferReadValid);
+        ReportWindow = GameNetworkMessage.ReadIntFromPacket(reportWindowCompressionInfo, ref bufferReadValid);
+        return bufferReadValid;
+    }
+
+    protected override void OnWrite()
+    {
+        GameNetworkMessage.WriteAgentIndexToPacket(AttackerAgentIndex);
+        GameNetworkMessage.WriteIntToPacket(Damage, CompressionBasic.AgentHitDamageCompressionInfo);
+        GameNetworkMessage.WriteIntToPacket(ReportWindow, reportWindowCompressionInfo);
+    }
+
+    protected override MultiplayerMessageFilter OnGetLogFilter()
+    {
+        return MultiplayerMessageFilter.General;
+    }
+
+    protected override string OnGetLogFormat()
+    {
+        return $"[FF Message] Hit by agent index {AttackerAgentIndex} for {Damage} damage. window: {ReportWindow}";
+    }
+}

--- a/src/Module.Server/Common/FriendlyFireReport/FriendlyFireMessageMode.cs
+++ b/src/Module.Server/Common/FriendlyFireReport/FriendlyFireMessageMode.cs
@@ -1,0 +1,11 @@
+namespace Crpg.Module.Common.FriendlyFireReport;
+
+public enum FriendlyFireMessageMode : byte
+{
+    Default = 0,
+    TeamDamageReportForVictim,
+    TeamDamageReportForAdmins,
+    TeamDamageReportForAttacker,
+    TeamDamageReportKick,
+    TeamDamageReportError,
+}

--- a/src/Module.Server/Common/FriendlyFireReport/FriendlyFireNotificationMessage.cs
+++ b/src/Module.Server/Common/FriendlyFireReport/FriendlyFireNotificationMessage.cs
@@ -1,0 +1,52 @@
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Crpg.Module.Common.FriendlyFireReport;
+
+[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromServer)]
+internal sealed class FriendlyFireNotificationMessage : GameNetworkMessage
+{
+    public string Message { get; private set; }
+    public FriendlyFireMessageMode Mode { get; private set; }
+    private readonly CompressionInfo.Integer messageModeCompressionInfo = new(
+        0,
+        (int)Enum.GetValues(typeof(FriendlyFireMessageMode)).Cast<FriendlyFireMessageMode>().Max(),
+        true);
+
+    public FriendlyFireNotificationMessage()
+    {
+        Message = string.Empty; // Default constructor for deserialization
+        Mode = FriendlyFireMessageMode.Default; // Default mode
+    }
+
+    public FriendlyFireNotificationMessage(string message, FriendlyFireMessageMode mode)
+    {
+        Message = message;
+        Mode = mode;
+    }
+
+    protected override bool OnRead()
+    {
+        bool bufferReadValid = true;
+        Message = GameNetworkMessage.ReadStringFromPacket(ref bufferReadValid);
+        Mode = (FriendlyFireMessageMode)GameNetworkMessage.ReadIntFromPacket(messageModeCompressionInfo, ref bufferReadValid);
+        return bufferReadValid;
+    }
+
+    protected override void OnWrite()
+    {
+        GameNetworkMessage.WriteStringToPacket(Message);
+        GameNetworkMessage.WriteIntToPacket((int)Mode, messageModeCompressionInfo);
+    }
+
+    protected override MultiplayerMessageFilter OnGetLogFilter()
+    {
+        return MultiplayerMessageFilter.General;
+    }
+
+    protected override string OnGetLogFormat()
+    {
+        return $"[FriendlyFireNotificationMessage ] ({Mode}) {Message}";
+    }
+}

--- a/src/Module.Server/Common/FriendlyFireReport/FriendlyFireReportClientBehavior.cs
+++ b/src/Module.Server/Common/FriendlyFireReport/FriendlyFireReportClientBehavior.cs
@@ -1,0 +1,148 @@
+using TaleWorlds.InputSystem;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace Crpg.Module.Common.FriendlyFireReport;
+
+internal class FriendlyFireReportClientBehavior : MissionNetwork
+{
+    private int _reportWindowSeconds = 0; // default unlimited, updated via FriendlyFireHitMessage
+    private bool _ctrlMWasPressed;
+    private DateTime? _lastHitMessageTime;
+    private int? _lastAttackerAgentIndex;
+    private string _lastAttackerName = "Unknown";
+    private bool _expiredMessageShown;
+
+    public override void OnMissionTick(float dt)
+    {
+        base.OnMissionTick(dt);
+
+        bool isCtrlDown = Input.IsKeyDown(InputKey.LeftControl) || Input.IsKeyDown(InputKey.RightControl);
+        bool isMPressed = Input.IsKeyPressed(InputKey.M);
+
+        if (isCtrlDown && isMPressed && !_ctrlMWasPressed) // ctrl+m pressed
+        {
+            _ctrlMWasPressed = true;
+
+            if (_lastHitMessageTime != null)
+            {
+                if (_reportWindowSeconds > 0)
+                {
+                    double elapsedSeconds = (DateTime.UtcNow - _lastHitMessageTime.Value).TotalSeconds;
+                    if (elapsedSeconds > _reportWindowSeconds)
+                    {
+                        if (!_expiredMessageShown)
+                        {
+                            InformationManager.DisplayMessage(new InformationMessage($"[FF] Time expired to report {_lastAttackerName} for teamhit.", Colors.Yellow));
+                            _expiredMessageShown = true;
+                        }
+
+                        // Ensure state is cleared regardless of whether the message was shown this frame
+                        _lastHitMessageTime = null;
+                        _lastAttackerAgentIndex = null;
+                        _lastAttackerName = "Unknown";
+
+                        return; // Don't report if window expired
+                    }
+                }
+
+                // Report is valid
+                HandleCtrlMPressed();
+            }
+
+            // Always clear state after attempt (successful or expired)
+            _lastHitMessageTime = null;
+            _lastAttackerAgentIndex = null;
+            _expiredMessageShown = false;
+            _lastAttackerName = "Unknown";
+        }
+
+        if (!isCtrlDown || !Input.IsKeyDown(InputKey.M))
+        {
+            _ctrlMWasPressed = false;
+        }
+    }
+
+    protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)
+    {
+        if (GameNetwork.IsClient)
+        {
+            base.AddRemoveMessageHandlers(registerer);
+            registerer.Register<FriendlyFireHitMessage>(HandleFriendlyFireHitMessage);
+            registerer.Register<FriendlyFireNotificationMessage>(HandleFriendlyFireTextMessage);
+        }
+    }
+
+    private void HandleCtrlMPressed()
+    {
+        GameNetwork.BeginModuleEventAsClient();
+        GameNetwork.WriteMessage(new FriendlyFireReportClientMessage());
+        GameNetwork.EndModuleEventAsClient();
+    }
+
+    private void HandleFriendlyFireHitMessage(FriendlyFireHitMessage message)
+    {
+        // Update _reportWindowSeconds set in Crpg.serverConfiguration
+        _reportWindowSeconds = message.ReportWindow;
+        _lastAttackerAgentIndex = message.AttackerAgentIndex;
+        _expiredMessageShown = false;
+
+        if (_lastAttackerAgentIndex == null || Mission.Current == null)
+        {
+            return;
+        }
+
+        Agent agent = Mission.Current.FindAgentWithIndex((int)_lastAttackerAgentIndex);
+        if (agent == null)
+        {
+            return;
+        }
+
+        _lastAttackerName = agent?.Name?.ToString() ?? "Unknown";
+        string outString = $"[FF] Team hit by {_lastAttackerName} (Dmg: {message.Damage}). Press Ctrl+M to mark that you believe this was intentional.";
+
+        if (_reportWindowSeconds > 0)
+        {
+            outString = $"[FF] Team hit by {_lastAttackerName} (Dmg: {message.Damage}). Press Ctrl+M to mark that you believe this was intentional. {_reportWindowSeconds} seconds remaining.";
+        }
+
+        InformationManager.DisplayMessage(new InformationMessage(outString, Colors.Red));
+
+        // New team hit → allow a fresh Ctrl+M
+        _ctrlMWasPressed = false;
+        // Set the timer for when the report window opens
+        _lastHitMessageTime = DateTime.UtcNow;
+    }
+
+    private void HandleFriendlyFireTextMessage(FriendlyFireNotificationMessage message)
+    {
+        FriendlyFireMessageMode mode = message.Mode;
+        Color msgColor;
+        switch (mode)
+        {
+            case FriendlyFireMessageMode.Default:
+                msgColor = Colors.Yellow;
+                break;
+            case FriendlyFireMessageMode.TeamDamageReportForVictim:
+                msgColor = Colors.Red;
+                break;
+            case FriendlyFireMessageMode.TeamDamageReportForAdmins:
+                msgColor = Colors.Magenta;
+                break;
+            case FriendlyFireMessageMode.TeamDamageReportForAttacker:
+                msgColor = Colors.Yellow;
+                break;
+            case FriendlyFireMessageMode.TeamDamageReportKick:
+                msgColor = Colors.Magenta;
+                break;
+            case FriendlyFireMessageMode.TeamDamageReportError:
+                msgColor = Colors.Yellow;
+                break;
+            default:
+                msgColor = Colors.Yellow;
+                break;
+        }
+
+        InformationManager.DisplayMessage(new InformationMessage(message.Message, msgColor));
+    }
+}

--- a/src/Module.Server/Common/FriendlyFireReport/FriendlyFireReportClientMessage.cs
+++ b/src/Module.Server/Common/FriendlyFireReport/FriendlyFireReportClientMessage.cs
@@ -1,0 +1,32 @@
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Network.Messages;
+
+namespace Crpg.Module.Common.FriendlyFireReport;
+
+[DefineGameNetworkMessageTypeForMod(GameNetworkMessageSendType.FromClient)]
+internal sealed class FriendlyFireReportClientMessage : GameNetworkMessage
+{
+    public FriendlyFireReportClientMessage()
+    {
+    }
+
+    protected override bool OnRead()
+    {
+        return true; // No data to read, always valid
+    }
+
+    protected override void OnWrite()
+    {
+        // No data to write
+    }
+
+    protected override MultiplayerMessageFilter OnGetLogFilter()
+    {
+        return MultiplayerMessageFilter.General;
+    }
+
+    protected override string OnGetLogFormat()
+    {
+        return "FriendlyFireReportClientMessage - Report Last Teamhit";
+    }
+}

--- a/src/Module.Server/Common/FriendlyFireReport/FriendlyFireReportServerBehavior.cs
+++ b/src/Module.Server/Common/FriendlyFireReport/FriendlyFireReportServerBehavior.cs
@@ -1,0 +1,427 @@
+using Crpg.Module.Api.Models.Users;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Diamond;
+
+namespace Crpg.Module.Common.FriendlyFireReport;
+
+internal class FriendlyFireReportServerBehavior : MissionNetwork
+{
+    private class TeamHitRecord
+    {
+        public DateTime Time { get; set; }
+        public NetworkCommunicator Victim { get; set; }
+        public float Damage { get; set; }
+        public string WeaponName { get; set; }
+        public bool WasReported { get; set; }
+        public bool HasDecayed { get; set; }
+
+        public TeamHitRecord(DateTime time, NetworkCommunicator victim, float damage, bool wasReported, bool hasDecayed = false, string weaponName = "unknown")
+        {
+            Time = time;
+            Victim = victim;
+            Damage = damage;
+            WeaponName = weaponName;
+            WasReported = wasReported;
+            HasDecayed = hasDecayed;
+        }
+
+        public bool CheckAndMarkDecay(DateTime now, double decaySeconds)
+        {
+            if (!HasDecayed && (now - Time).TotalSeconds > decaySeconds)
+            {
+                HasDecayed = true;
+            }
+
+            return HasDecayed;
+        }
+    }
+
+    // Track hit info of all teamhits
+    private readonly Dictionary<NetworkCommunicator, List<TeamHitRecord>> _teamHitHistory = new();
+    // Track which peer last team-damaged a specific peer
+    private readonly Dictionary<NetworkCommunicator, NetworkCommunicator> _lastTeamHitBy = new();
+    private MultiplayerRoundController? _roundController;
+    public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+
+    public override void AfterStart()
+    {
+        _roundController = Mission.Current.GetMissionBehavior<MultiplayerRoundController>();
+        if (_roundController != null)
+        {
+            _roundController.OnRoundStarted += OnRoundStarted;
+        }
+    }
+
+    public override void OnRemoveBehavior()
+    {
+        base.OnRemoveBehavior();
+        if (_roundController != null)
+        {
+            _roundController.OnRoundStarted -= OnRoundStarted;
+        }
+    }
+
+    public override void OnAgentHit(Agent affectedAgent, Agent affectorAgent, in MissionWeapon affectorWeapon, in Blow blow, in AttackCollisionData attackCollisionData)
+    {
+        base.OnAgentHit(affectedAgent, affectorAgent, affectorWeapon, blow, attackCollisionData);
+
+        if (!CrpgServerConfiguration.IsFriendlyFireReportEnabled)
+        {
+            return; // If control M reporting is disabled, do not process team hits
+        }
+
+        if (Mission.Current?.GetMissionBehavior<MultiplayerWarmupComponent>()?.IsInWarmup ?? false)
+        {
+            return; // Still in warmup phase
+        }
+
+        if (affectedAgent == null || affectorAgent == null || affectedAgent == affectorAgent)
+        {
+            return;
+        }
+
+        if (affectedAgent.IsMount) // Check if victim a mount
+        {
+            if (affectedAgent.RiderAgent != null && affectedAgent.RiderAgent.IsActive())
+            {
+                affectedAgent = affectedAgent.RiderAgent; // use the rider as the victim
+            }
+            else
+            {
+                return; // ignore hits to mounts without riders
+            }
+        }
+
+        if (affectorAgent.IsMount) // Check if the attacker agent is a mount
+        {
+            if (affectorAgent.RiderAgent != null && affectorAgent.RiderAgent.IsActive())
+            {
+                affectorAgent = affectorAgent.RiderAgent; // use the rider as the attacker
+            }
+            else
+            {
+                return; // ignore hits from mounts without riders
+            }
+        }
+
+        // Check if both agents are player controlled, use rider (set above) if mount was the attacker or victim
+        if (!affectedAgent.IsPlayerControlled || !affectorAgent.IsPlayerControlled)
+        {
+            return;
+        }
+
+        // Same team
+        if (affectedAgent.Team?.TeamIndex != affectorAgent.Team?.TeamIndex)
+        {
+            return; // not a team hit
+        }
+
+        NetworkCommunicator? affectorNetworkPeer = affectorAgent.MissionPeer?.GetNetworkPeer(); // attacker
+        NetworkCommunicator? affectedNetworkPeer = affectedAgent.MissionPeer?.GetNetworkPeer(); // victim
+
+        if (affectorNetworkPeer == null || affectedNetworkPeer == null || affectorNetworkPeer == affectedNetworkPeer)
+        {
+            return; // No network peers available or same peer
+        }
+
+        string weaponName = "unknown";
+        if (!affectorWeapon.IsEmpty && !affectorWeapon.IsEqualTo(MissionWeapon.Invalid) && affectorWeapon.Item != null)
+        {
+            weaponName = affectorWeapon.Item.Name.ToString();
+        }
+
+        if (!_teamHitHistory.TryGetValue(affectorNetworkPeer, out var hitList))
+        {
+            hitList = new List<TeamHitRecord>();
+            _teamHitHistory[affectorNetworkPeer] = hitList;
+        }
+
+        hitList.Add(new TeamHitRecord(DateTime.UtcNow, affectedNetworkPeer, attackCollisionData.InflictedDamage, false, false, weaponName));
+
+        // Track last team hitter for the affected agent
+        _lastTeamHitBy[affectedNetworkPeer] = affectorNetworkPeer;
+
+        if (GameNetwork.IsServer)
+        {
+            GameNetwork.BeginModuleEventAsServer(affectedNetworkPeer);
+            GameNetwork.WriteMessage(new FriendlyFireHitMessage(affectorAgent.Index, attackCollisionData.InflictedDamage, CrpgServerConfiguration.FriendlyFireReportWindowSeconds));
+            GameNetwork.EndModuleEventAsServer();
+        }
+    }
+
+    public override void OnAgentRemoved(Agent affectedAgent, Agent affectorAgent, AgentState agentState, KillingBlow blow)
+    {
+        base.OnAgentRemoved(affectedAgent, affectorAgent, agentState, blow);
+    }
+
+    public override void OnPlayerDisconnectedFromServer(NetworkCommunicator networkPeer)
+    {
+        base.OnPlayerDisconnectedFromServer(networkPeer);
+
+        // Remove hits where this peer was the attacker
+        _teamHitHistory.Remove(networkPeer);
+
+        // Remove hits where this peer was the victim inside other players' hit records
+        foreach (var hitList in _teamHitHistory.Values)
+        {
+            hitList.RemoveAll(hit => hit.Victim == networkPeer);
+        }
+
+        // remove entries where this peer was the victim
+        _lastTeamHitBy.Remove(networkPeer);
+
+        // remove entries where this peer was the attacker
+        var victims = _lastTeamHitBy
+            .Where(kvp => kvp.Value == networkPeer)
+            .Select(kvp => kvp.Key)
+            .ToList();
+        foreach (var victimPeer in victims)
+        {
+            // SendClientDisplayMessage(victimPeer, $"[FF] Your last teamhit attacker {networkPeer.UserName} has left the match.", FriendlyFireMessageMode.TeamDamageReportError);
+            _lastTeamHitBy.Remove(victimPeer);
+        }
+    }
+
+    public (int activeReported, int decayedReported, int notReported) GetReportedTeamHitBreakdown(NetworkCommunicator peer, bool detailed = true)
+    {
+        if (peer == null || !_teamHitHistory.TryGetValue(peer, out var hitList))
+        {
+            return (0, 0, 0);
+        }
+
+        int activeReported = 0;
+        int decayedReported = 0;
+        int notReported = 0;
+        DateTime now = DateTime.UtcNow;
+
+        foreach (var hit in hitList)
+        {
+            if (!hit.WasReported)
+            {
+                if (detailed)
+                {
+                    notReported++;
+                }
+
+                continue;
+            }
+
+            hit.CheckAndMarkDecay(now, CrpgServerConfiguration.FriendlyFireReportDecaySeconds);
+
+            if (hit.HasDecayed)
+            {
+                if (detailed)
+                {
+                    decayedReported++;
+                }
+            }
+            else
+            {
+                activeReported++;
+            }
+        }
+
+        return (activeReported, decayedReported, notReported);
+    }
+
+    public int CountTotalHitsAgainstVictim(NetworkCommunicator attacker, NetworkCommunicator victim)
+    {
+        if (!_teamHitHistory.TryGetValue(attacker, out var hits))
+        {
+            return 0;
+        }
+
+        return hits.Count(hit => hit.Victim == victim);
+    }
+
+    protected override void AddRemoveMessageHandlers(GameNetwork.NetworkMessageHandlerRegistererContainer registerer)
+    {
+        if (GameNetwork.IsServer)
+        {
+            base.AddRemoveMessageHandlers(registerer);
+            registerer.Register<FriendlyFireReportClientMessage>((peer, message) =>
+            {
+                OnFriendlyFireReportRecieved(peer, message);
+                return true;
+            });
+        }
+    }
+
+    private void OnRoundStarted()
+    {
+        _lastTeamHitBy.Clear(); // clear last person to hit a peer
+
+        // mark all reported hits as decayed on round start but preserve data
+        if (CrpgServerConfiguration.IsFriendlyFireReportDecayOnRoundStartEnabled)
+        {
+            foreach (var hitList in _teamHitHistory.Values)
+            {
+                foreach (var hit in hitList)
+                {
+                    if (hit.WasReported)
+                    {
+                        hit.HasDecayed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    private void OnFriendlyFireReportRecieved(NetworkCommunicator peer, FriendlyFireReportClientMessage message)
+    {
+        if (!CrpgServerConfiguration.IsFriendlyFireReportEnabled)
+        {
+            if (peer != null && peer.IsConnectionActive)
+            {
+                SendClientDisplayMessage(peer, "[FF] Ctrl+M reporting is currently disabled on this server.", FriendlyFireMessageMode.TeamDamageReportError);
+            }
+
+            return; // If control M reporting is disabled, do not process team hit reports
+        }
+
+        if (peer == null || !peer.IsConnectionActive)
+        {
+            return;
+        }
+
+        if (Mission.Current?.GetMissionBehavior<MultiplayerWarmupComponent>()?.IsInWarmup ?? false)
+        {
+            return; // Still in warmup phase
+        }
+
+        if (!_lastTeamHitBy.TryGetValue(peer, out NetworkCommunicator? attackingPeer))
+        {
+            return; // No record of a team hit
+        }
+
+        if (attackingPeer == null || !attackingPeer.IsConnectionActive)
+        {
+            SendClientDisplayMessage(peer, "[FF] No connected attacker peer found for your report.", FriendlyFireMessageMode.TeamDamageReportError);
+            return; // Attacker is not active
+        }
+
+        // Mark the last hit as reported
+        var recentHit = _teamHitHistory[attackingPeer].LastOrDefault(h =>
+            h.Victim == peer &&
+            !h.WasReported &&
+            (CrpgServerConfiguration.FriendlyFireReportWindowSeconds == 0 ||
+            (DateTime.UtcNow - h.Time).TotalSeconds < CrpgServerConfiguration.FriendlyFireReportWindowSeconds));
+
+        if (recentHit != null)
+        {
+            recentHit.WasReported = true;
+        }
+        else
+        {
+            SendClientDisplayMessage(peer, "[FF] No recent team hit found to report.", FriendlyFireMessageMode.TeamDamageReportError);
+            return; // No recent unreported hit found
+        }
+
+        // Get Teamhits by attacker
+        var (countActive, countDecayed, countNotReported) = GetReportedTeamHitBreakdown(attackingPeer);
+        int countAttacksOnVictim = CountTotalHitsAgainstVictim(attackingPeer, peer);
+        int maxHits = CrpgServerConfiguration.FriendlyFireReportMaxHits;
+
+        // Notify the attacker about the report
+        SendClientDisplayMessage(attackingPeer, $"[FF] {peer.UserName} reported your team hit (Dmg: {recentHit.Damage}). {countActive}/{maxHits} team hits until getting kicked.", FriendlyFireMessageMode.TeamDamageReportForAttacker);
+
+        // Notify the victim about the report
+        SendClientDisplayMessage(peer, $"[FF] Reported {attackingPeer.UserName} for team hit (Dmg: {recentHit.Damage}).");
+
+        // Notify all admins about the report
+        if (CrpgServerConfiguration.IsFriendlyFireReportNotifyAdminsEnabled)
+        {
+            SendClientDisplayMessageToAdmins($"[FF] {attackingPeer.UserName} reported by {peer.UserName}. [{countActive}/{maxHits}] decayed: {countDecayed} not reported: {countNotReported} on reporter: {countAttacksOnVictim}");
+        }
+
+        // Logging
+        TryLogFriendlyFire(peer, attackingPeer, countActive, countDecayed, countNotReported, countAttacksOnVictim, (int)recentHit.Damage, recentHit.WeaponName);
+
+        if (countActive >= maxHits)
+        {
+            SendClientDisplayMessage(attackingPeer, $"[FF] You have been kicked for excessive team hits ({maxHits})", FriendlyFireMessageMode.TeamDamageReportKick);
+            SendClientDisplayMessageToAllExcept(attackingPeer, $"[FF] {attackingPeer.UserName} has been kicked for excessive team hits ({maxHits}).", FriendlyFireMessageMode.TeamDamageReportKick);
+
+            TryLogKickedForFriendlyFire(attackingPeer, countActive, countDecayed, countNotReported);
+
+            KickHelper.Kick(attackingPeer, DisconnectType.KickedDueToFriendlyDamage);
+        }
+    }
+
+    private void TryLogFriendlyFire(NetworkCommunicator peer, NetworkCommunicator attackingPeer, int reportedHits, int decayedHits, int unreportedHits, int onReporterHits, int damage, string weaponName)
+    {
+        var peerComponent = peer?.GetComponent<CrpgPeer>();
+        var attackerComponent = attackingPeer?.GetComponent<CrpgPeer>();
+
+        if (peerComponent?.User == null || attackerComponent?.User == null)
+        {
+            return;
+        }
+
+        int peerUserId = peerComponent.User.Id;
+        int attackerUserId = attackerComponent.User.Id;
+
+        Mission.Current?.GetMissionBehavior<CrpgActivityLogsBehavior>()
+            ?.AddTeamHitReportedLogWrapper(peerUserId, attackerUserId, reportedHits, decayedHits, unreportedHits, onReporterHits, damage, weaponName);
+    }
+
+    private void TryLogKickedForFriendlyFire(NetworkCommunicator peer, int reportedHits, int decayedHits, int unreportedHits)
+    {
+        var peerComponent = peer?.GetComponent<CrpgPeer>();
+
+        if (peerComponent?.User == null)
+        {
+            return;
+        }
+
+        int peerUserId = peerComponent.User.Id;
+
+        Mission.Current?.GetMissionBehavior<CrpgActivityLogsBehavior>()
+            ?.AddTeamHitReportedUserKickedLogWrapper(peerUserId, reportedHits, decayedHits, unreportedHits);
+    }
+
+    private void SendClientDisplayMessage(NetworkCommunicator peer, string displayText, FriendlyFireMessageMode messageMode = FriendlyFireMessageMode.Default)
+    {
+        if (peer == null || !peer.IsConnectionActive)
+        {
+            return;
+        }
+
+        if (!Enum.IsDefined(typeof(FriendlyFireMessageMode), messageMode))
+        {
+            messageMode = FriendlyFireMessageMode.Default; // fallback to safe default
+        }
+
+        GameNetwork.BeginModuleEventAsServer(peer);
+        GameNetwork.WriteMessage(new FriendlyFireNotificationMessage(displayText, messageMode));
+        GameNetwork.EndModuleEventAsServer();
+    }
+
+    private void SendClientDisplayMessageToAllExcept(NetworkCommunicator excludedPeer, string displayText, FriendlyFireMessageMode messageMode = FriendlyFireMessageMode.Default)
+    {
+        foreach (var peer in GameNetwork.NetworkPeers)
+        {
+            if (peer.IsConnectionActive && peer != excludedPeer)
+            {
+                SendClientDisplayMessage(peer, displayText, messageMode);
+            }
+        }
+    }
+
+    private void SendClientDisplayMessageToAdmins(string displayText)
+    {
+        foreach (var peer in GameNetwork.NetworkPeers)
+        {
+            if (peer.IsConnectionActive)
+            {
+                var crpgUser = peer.GetComponent<CrpgPeer>()?.User;
+                if (crpgUser != null && crpgUser.Role is CrpgUserRole.Moderator or CrpgUserRole.Admin)
+                {
+                    SendClientDisplayMessage(peer, displayText, FriendlyFireMessageMode.TeamDamageReportForAdmins);
+                }
+            }
+        }
+    }
+}

--- a/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
@@ -1,6 +1,7 @@
 using Crpg.Module.Common;
 using Crpg.Module.Common.AmmoQuiverChange;
 using Crpg.Module.Common.Commander;
+using Crpg.Module.Common.FriendlyFireReport;
 using Crpg.Module.Common.HotConstants;
 using Crpg.Module.Common.TeamSelect;
 using Crpg.Module.Modes.Skirmish;
@@ -148,6 +149,7 @@ internal class CrpgBattleGameMode : MissionBasedMultiplayerGameMode
                     new MultiplayerMissionAgentVisualSpawnComponent(), // expose method to spawn an agent
                     new CrpgCommanderBehaviorClient(),
                     new AmmoQuiverChangeBehaviorClient(),
+                    new FriendlyFireReportClientBehavior(), // Ctrl+M to report friendly fire
 #endif
                     battleClient,
                     new MultiplayerTimerComponent(), // round timer
@@ -202,6 +204,7 @@ internal class CrpgBattleGameMode : MissionBasedMultiplayerGameMode
                     new BreakableWeaponsBehaviorServer(),
                     new CrpgCustomTeamBannersAndNamesServer(roundController),
                     new CrpgCommanderBehaviorServer(),
+                    new FriendlyFireReportServerBehavior(), // Ctrl+M to report friendly fire
 #else
                     new MultiplayerRoundComponent(),
                     new MultiplayerAchievementComponent(),

--- a/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
@@ -1,6 +1,7 @@
 ﻿using Crpg.Module.Common;
 using Crpg.Module.Common.AmmoQuiverChange;
 using Crpg.Module.Common.Commander;
+using Crpg.Module.Common.FriendlyFireReport;
 using Crpg.Module.Common.TeamSelect;
 using Crpg.Module.Modes.Siege;
 using Crpg.Module.Modes.Warmup;
@@ -117,6 +118,7 @@ internal class CrpgConquestGameMode : MissionBasedMultiplayerGameMode
                 new CrpgCommanderBehaviorClient(),
                 new CrpgRespawnTimerClient(),
                 new AmmoQuiverChangeBehaviorClient(),
+                new FriendlyFireReportClientBehavior(), // Ctrl+M to report friendly fire
 #endif
                 warmupComponent,
                 new CrpgConquestClient(),
@@ -152,6 +154,7 @@ internal class CrpgConquestGameMode : MissionBasedMultiplayerGameMode
                 new DrowningBehavior(),
                 new PopulationBasedEntityVisibilityBehavior(lobbyComponent),
                 new CrpgCommanderBehaviorServer(),
+                new FriendlyFireReportServerBehavior(), // Ctrl+M to report friendly fire
                 new CrpgRespawnTimerServer(conquestServer, spawnBehavior),
 #else
                 new MultiplayerAchievementComponent(),

--- a/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
@@ -53,6 +53,7 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
     public override bool UseRoundController() => false;
 
     public MBReadOnlyList<FlagCapturePoint> AllCapturePoints { get; private set; } = new(new List<FlagCapturePoint>());
+    public event Action<int>? ConquestStageStarted;
 
     public override void OnBehaviorInitialize()
     {
@@ -335,6 +336,8 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
         {
             s.SetSpawnOverride(0.5f);
         }
+
+        ConquestStageStarted?.Invoke(stageIndex);
     }
 
     private void TickFlags()

--- a/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
@@ -1,6 +1,7 @@
 using Crpg.Module.Common;
 using Crpg.Module.Common.AmmoQuiverChange;
 using Crpg.Module.Common.Commander;
+using Crpg.Module.Common.FriendlyFireReport;
 using Crpg.Module.Common.TeamSelect;
 using Crpg.Module.Modes.Warmup;
 using Crpg.Module.Notifications;
@@ -118,6 +119,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
                 new MultiplayerMissionAgentVisualSpawnComponent(), // expose method to spawn an agent
                 new CrpgCommanderBehaviorClient(),
                 new AmmoQuiverChangeBehaviorClient(),
+                new FriendlyFireReportClientBehavior(), // Ctrl+M to report friendly fire
 #endif
                 dtvClient,
                 new MultiplayerTimerComponent(), // round timer
@@ -154,6 +156,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
                 new DrowningBehavior(),
                 new PopulationBasedEntityVisibilityBehavior(lobbyComponent),
                 new CrpgCommanderBehaviorServer(),
+                new FriendlyFireReportServerBehavior(), // Ctrl+M to report friendly fire
 #else
                 new MultiplayerAchievementComponent(),
                 MissionMatchHistoryComponent.CreateIfConditionsAreMet(),

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -58,7 +58,6 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private CrpgDtvWave CurrentWaveData => _dtvData.Rounds[_currentRound].Waves[_currentWave];
     private int WavesCountForCurrentRound => CurrentRoundData.Waves.Count;
     public event Action<int>? DtvRoundStarted;
-    public event Action? DtvMapEnded;
 
     [Flags]
     private enum StonePileRegenerateOptions

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -57,6 +57,8 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
     private CrpgDtvRound CurrentRoundData => _dtvData.Rounds[_currentRound];
     private CrpgDtvWave CurrentWaveData => _dtvData.Rounds[_currentRound].Waves[_currentWave];
     private int WavesCountForCurrentRound => CurrentRoundData.Waves.Count;
+    public event Action<int>? DtvRoundStarted;
+    public event Action? DtvMapEnded;
 
     [Flags]
     private enum StonePileRegenerateOptions
@@ -138,7 +140,7 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
             SendDataToPeers(new CrpgDtvVipSpawn { VipAgentIndex = agent.Index });
         }
 
-            // Synchronize health with all clients to make the spectator health bar work.
+        // Synchronize health with all clients to make the spectator health bar work.
         agent.UpdateSyncHealthToAllClients(true);
     }
 
@@ -318,6 +320,8 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         _currentRoundStartTime = MissionTime.Now;
         _waveStartTimer = new MissionTimer(15f);
         _waveStarted = false;
+
+        DtvRoundStarted?.Invoke(_currentRound);
     }
 
     private void StartNextWave()

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
@@ -1,6 +1,7 @@
 using Crpg.Module.Common;
 using Crpg.Module.Common.AmmoQuiverChange;
 using Crpg.Module.Common.Commander;
+using Crpg.Module.Common.FriendlyFireReport;
 using Crpg.Module.Common.HotConstants;
 using Crpg.Module.Common.TeamSelect;
 using Crpg.Module.Modes.Warmup;
@@ -104,6 +105,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
         CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: true);
         CrpgTeamDeathmatchServer teamDeathmatchServer = new(scoreboardComponent, rewardServer);
 
+
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent, null);
         CrpgTeamSelectClientComponent teamSelectComponent = new();
@@ -120,6 +122,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
                 new CrpgCommanderBehaviorClient(),
                 new AmmoQuiverChangeBehaviorClient(),
                 new CrpgRespawnTimerClient(),
+                new FriendlyFireReportClientBehavior(), // Ctrl+M to report friendly fire
 #endif
                 new CrpgTeamDeathmatchClient(),
                 new MultiplayerTimerComponent(),
@@ -159,6 +162,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
                 new CrpgCustomTeamBannersAndNamesServer(null),
                 new CrpgCommanderBehaviorServer(),
                 new CrpgRespawnTimerServer(teamDeathmatchServer, spawnBehavior),
+                new FriendlyFireReportServerBehavior(), // Ctrl+M to report friendly fire
 #else
                 new MultiplayerAchievementComponent(),
                 MissionMatchHistoryComponent.CreateIfConditionsAreMet(),

--- a/src/Module.Server/Module.Server.csproj
+++ b/src/Module.Server/Module.Server.csproj
@@ -22,6 +22,7 @@
     <ContentWithTargetPath Include="MapRotation\*.txt" TargetPath="..\..\%(Filename).txt" CopyToOutputDirectory="Always" />
     <Compile Remove="..\Module.Server\HarmonyPatches\MissionNetworkComponentPatch.cs" />
     <Compile Remove="..\Module.Server\HarmonyPatches\SendPeerInformationsToPeerPatch.cs" />
+    <Compile Remove="..\Module.Server\Common\FriendlyFireReport\FriendlyFireReportClientBehavior.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tracks team-hit information.

- press ctrl+m to report the last person that attacked you. (within report window time. 10 seconds by default)
- if a user gets 5 active reports for team-hit, they get kicked from the server.
- if a user goes 60 seconds without a teamhit, 1 is subtracted from active reports (decay)
- all hits are decayed on round start but still tracks team-hit information until map change.
- disabled in warmup


Server configurable settings and default values.
```
crpg_ff_report_enabled true
crpg_ff_report_max_hit_count 5
crpg_ff_report_notify_admins true
crpg_ff_report_decay_seconds  60
crpg_ff_report_window_seconds 10
crpg_ff_report_decay_on_round_start true
```

crpg_ff_report_enabled [true/false]
crpg_ff_report_max_hit_count [1-10]
crpg_ff_report_notify_admins [true/false]
crpg_ff_report_decay_seconds [1-200]
crpg_ff_report_window_seconds [0-200]  --0 is unlimited time to report
crpg_ff_report_decay_on_round_start [true/false]


!ff [playername/id]  -- admin command, displays tracked teamhit information for player. (number of active/decayed/unreported/total team hits)

also logging to website added what I could. will need additional stuff by orle.