### PR TITLE
Crush through reduction

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -390,7 +390,7 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
             ? Math.Max(defenderShieldSkill * 6 + 3, defenderStrengthSkill)
             : defenderStrengthSkill;
         int randomNumber = MBRandom.RandomInt(0, 1000);
-        return randomNumber / 10f < Math.Pow(attackerPower / defenderDefendPower / 2.5f, 1.8f) * 100f;
+        return randomNumber / 10f < Math.Pow(attackerPower / defenderDefendPower / 2.6f, 2.6f) * 100f;
     }
 
     // MissionCombatMechanicsHelper.cs/DecideMountRearedByBlow


### PR DESCRIPTION
Crush through change to reduce chances on "full" melee builds, whilst keeping viable against more AGI characters. New chances:

<img width="634" height="330" alt="image" src="https://github.com/user-attachments/assets/6126b21d-a185-4b58-a99b-84c21bd4c162" />