### PR TITLE
mod: Increase New Player Gold to 100k

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -52,7 +52,7 @@
   "defaultRatingDeviation": 350,
   "defaultRatingVolatility": 0.06,
   "defaultRole": "User",
-  "defaultGold": 30000,
+  "defaultGold": 100000,
   "defaultHeirloomPoints": 0,
   "clanTagMinLength": 2,
   "clanTagMaxLength": 4,


### PR DESCRIPTION
Increase new player gold to 100k to address issues of new players struggling for upkeep

It has become apparent that new players are typically experiencing feeling of struggle for gold and upkeep when they first start out, typically speaking when a new player starts out they are likely to not understand our systems and this will lead to them "splashing out" and wasting the gold they have available to them very quickly, which in turn leads to them going bankrupt fast.

This amount of gold effectively acts as a sort of "trial period" in which said new player can still do the same things, but is much more likely to end up with a relative cushion to pad their experience. The intent of which is to increase the likelihood that they stick around long-term.

It is not an inherent fix to new players lacking understanding, but it will make it a lot simpler for a new player to have a period of experimentation before getting used to cRPG's aspects of grind (one of which is gold)