### PR TITLE
mod: increase nudge cooldown by 0.25 seconds

### DIFF
--- a/src/Module.Server/ModuleData/combat_parameters.xml
+++ b/src/Module.Server/ModuleData/combat_parameters.xml
@@ -20,11 +20,11 @@
     <def name="thrust_ladder_rot_limit_right" val="57.3" /> <!-- native is 57.3 -->
     <def name="overswing_ladder_rot_limit_left"  val="67.3" />
     <def name="overswing_ladder_rot_limit_right" val="57.3" />
-    <def name="weapon_1h_bash_cooldown" val="2.0" />
-    <def name="weapon_2h_bash_cooldown" val="2.0" />
-    <def name="weapon_spear_bash_cooldown" val="2.0" />
-    <def name="shield_bash_cooldown" val="2.4" />
-    <def name="hand_shield_bash_cooldown" val="2.4" />
+    <def name="weapon_1h_bash_cooldown" val="1.75" />
+    <def name="weapon_2h_bash_cooldown" val="1.75" />
+    <def name="weapon_spear_bash_cooldown" val="1.75" />
+    <def name="shield_bash_cooldown" val="2.15" />
+    <def name="hand_shield_bash_cooldown" val="2.15" />
 
   </definitions>
 


### PR DESCRIPTION
Boost nudge cooldown by 0.25 seconds to address unintended use-cases

Nudges have been found to be too spammy, and in some instances can be abused to create a "cycle" where one can "infinitely" overhead spam a person and repeatedly deny a persons ability to retaliate in combat. Though there are counters to this behaviour (counter-nudging, playing for space) it was determined that this behaviour was unhealthy for cRPG and it would be better to nerf nudging slightly to help prohibit this behaviour.

## OLD
```
    <def name="weapon_1h_bash_cooldown" val="1.5" />
    <def name="weapon_2h_bash_cooldown" val="1.5" />
    <def name="weapon_spear_bash_cooldown" val="1.5" />
    <def name="shield_bash_cooldown" val="1.9" />
    <def name="hand_shield_bash_cooldown" val="1.9" />
```

## NEW
```
    <def name="weapon_1h_bash_cooldown" val="1.75" />
    <def name="weapon_2h_bash_cooldown" val="1.75" />
    <def name="weapon_spear_bash_cooldown" val="1.75" />
    <def name="shield_bash_cooldown" val="2.15" />
    <def name="hand_shield_bash_cooldown" val="2.15" />
```