### PR TITLE
Temporary shield stun fix

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentApplyDamageModel.cs
@@ -336,25 +336,11 @@ internal class CrpgAgentApplyDamageModel : MultiplayerAgentApplyDamageModel
     ref float attackerStunPeriod,
     ref float defenderStunPeriod)
     {
-        // Let base game handle normal stun logic
+        // Vanilla stun logic, need to reintroduce cRPG versions
         base.CalculateDefendedBlowStunMultipliers(
             attackerAgent, defenderAgent, collisionResult,
             attackerWeapon, defenderWeapon,
             ref attackerStunPeriod, ref defenderStunPeriod);
-
-        // Only tweak for shield blocks
-        if (collisionResult == CombatCollisionResult.Blocked && defenderAgent.WieldedOffhandWeapon.IsShield())
-        {
-            int shieldSkill = 0;
-            if (defenderAgent.Origin is CrpgBattleAgentOrigin crpgOrigin)
-            {
-                shieldSkill = crpgOrigin.Skills.Skills.GetPropertyValue(CrpgSkills.Shield);
-            }
-
-            defenderStunPeriod = 1 / MathHelper.RecursivePolynomialFunctionOfDegree2(shieldSkill, _constants.ShieldDefendStunMultiplierForSkillRecursiveCoefs);
-
-            return;
-        }
     }
 
     // TODO : Consider reworking once https://forums.taleworlds.com/index.php?threads/missioncombatmechanicshelper-getdefendcollisionresults-bypass-strikemagnitudecalculationmodel.459379 is fixed


### PR DESCRIPTION
Now rely on Native for all weapon stun effects until we can reintroduce cRPG effects. Means shield skill will have no effect on duration of the stun I think.