### PR TITLE
mod: fix crouch speed

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -396,6 +396,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         props.BipedalRangedReadySpeedMultiplier = ManagedParameters.Instance.GetManagedParameter(ManagedParametersEnum.BipedalRangedReadySpeedMultiplier);
         props.BipedalRangedReloadSpeedMultiplier = ManagedParameters.Instance.GetManagedParameter(ManagedParametersEnum.BipedalRangedReloadSpeedMultiplier);
         props.CombatMaxSpeedMultiplier = bipedalCombatSpeedMaxMultiplier;
+        props.CrouchedSpeedMultiplier = 1f;
 
         if (equippedItem != null)
         {


### PR DESCRIPTION
`CrouchedSpeedMultiplier` was introduced in v1.3.4 and it is basically set to `1.0f` everywhere. Supersedes https://github.com/crpg2/crpg/pull/612.