### PR TITLE
webapi: add PartyStatus.Dead

### DIFF
--- a/src/Application/Parties/Commands/UpdatePartyPositionsCommand.cs
+++ b/src/Application/Parties/Commands/UpdatePartyPositionsCommand.cs
@@ -24,6 +24,7 @@ public record UpdatePartyPositionsCommand : IMediatorRequest
 
         private static readonly PartyStatus[] UnattackablePartyStatuses =
         [
+            PartyStatus.Dead,
             PartyStatus.IdleInSettlement,
             PartyStatus.RecruitingInSettlement,
             PartyStatus.InBattle,

--- a/src/Domain/Entities/Parties/PartyStatus.cs
+++ b/src/Domain/Entities/Parties/PartyStatus.cs
@@ -6,6 +6,11 @@ namespace Crpg.Domain.Entities.Parties;
 public enum PartyStatus
 {
     /// <summary>
+    /// Died after a battle. Require user action to respawn.
+    /// </summary>
+    Dead,
+
+    /// <summary>
     /// Inactive.
     /// </summary>
     Idle,

--- a/test/Application.UTest/Parties/UpdatePartyPositionsCommandTest.cs
+++ b/test/Application.UTest/Parties/UpdatePartyPositionsCommandTest.cs
@@ -468,4 +468,6 @@ public class UpdatePartyPositionsCommandTest : TestBase
     //     Assert.That(battle.Fighters[1].Side, Is.EqualTo(BattleSide.Defender));
     //     Assert.That(battle.Fighters[1].Commander, Is.True);
     // }
+
+    // TODO: if dead, don't update anything + can't be attacked.
 }


### PR DESCRIPTION
We don't want to have a ton of idle parties on the map, that could greatly impact the user experience. This new status will be used when a party died after a battle. They will have to manually click a respawn button if they want to play again.

It seems like there is not much code to update to support this new status.

It didn't create a migration because it seems like they are lot of pending ones?