### PR TITLE
mod: fix shield hit box

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -121,6 +121,9 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         {
             InitializeMountAgentStats(agent, spawnEquipment, agentDrivenProperties);
         }
+
+        // Multiplier for defend speed when blocking with an offhand weapon (e.g. shield).
+        agentDrivenProperties.OffhandWeaponDefendSpeedMultiplier = 1f;
     }
 
     public override void UpdateAgentStats(Agent agent, AgentDrivenProperties agentDrivenProperties)
@@ -649,6 +652,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         props.AiRangerHorizontalErrorMultiplier = equippedItemLevelComplement * 0.035f;
         props.AiRangerVerticalErrorMultiplier = equippedItemLevelComplement * 0.15f;
         props.AiRangerHorizontalErrorMultiplier = equippedItemLevelComplement * 0.05f;
+        props.AiShooterErrorWoRangeUpdate = 0f;
         props.AIAttackOnDecideChance = MathF.Clamp(0.1f * CalculateAIAttackOnDecideMaxValue() * (3f - agent.Defensiveness), 0.05f, 1f);
         props.SetStat(DrivenProperty.UseRealisticBlocking, agent.Controller != AgentControllerType.Player ? 1f : 0f);
         props.AiWeaponFavorMultiplierMelee = 1f;


### PR DESCRIPTION
I understand that `OffhandWeaponDefendSpeedMultiplier` is the speed to block with the shield. It's actually a feature request I made a decade ago. cRPG didn't set a value so I suppose even if we would see the character blocking, the shield didn't move because the speed is 0. The shield stays still on the side which explains why we could block arrows from the side.

`AiShooterErrorWoRangeUpdate` is unrelated, it's just something we didn't set either. I also found a bunch of new properties:
- ThrowingWeaponDamageMultiplierBonus
- MeleeWeaponDamageMultiplierBonus
- ArmorPenetrationMultiplierCrossbow
- ArmorPenetrationMultiplierBow
- DamageMultiplierBonus