### PR TITLE
mod: fix DTV stuck bot highlight crash and improvements

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvStuckBotHighlighter.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvStuckBotHighlighter.cs
@@ -1,5 +1,6 @@
 using TaleWorlds.Core;
 using TaleWorlds.Library;
+using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 
 namespace Crpg.Module.Modes.Dtv;
@@ -12,10 +13,13 @@ internal class CrpgDtvStuckBotHighlighter : MissionLogic
     /// <summary>The minimum wave age in seconds to start counting down before highlighting bots.</summary>
     private const float MinWaveAge = 60f;
 
+    /// <summary>The maximum number of alive bots to start highlighting.</summary>
+    private const int MaxBotsToHighlight = 5;
+
     private readonly CrpgDtvClient _dtvClient;
+    private readonly List<Agent> _highlightedAgents = new();
     private MissionTime _lastAttackerBotKillTime;
     private MissionTime _waveStartTime;
-    private bool _botsHighlighted;
     private bool _waveActive;
 
     public CrpgDtvStuckBotHighlighter(CrpgDtvClient dtvClient)
@@ -40,11 +44,13 @@ internal class CrpgDtvStuckBotHighlighter : MissionLogic
     {
         base.OnMissionTick(dt);
 
-        if (!_botsHighlighted
+        int activeBotCount = Mission.AttackerTeam?.ActiveAgents.Count(a => !a.IsPlayerControlled) ?? 0;
+        if (_highlightedAgents.Count == 0
             && _waveActive
             && _waveStartTime.ElapsedSeconds >= MinWaveAge + HighlightDelay
             && _lastAttackerBotKillTime.ElapsedSeconds >= HighlightDelay
-            && Mission.AttackerTeam?.ActiveAgents.Count > 0)
+            && activeBotCount > 0
+            && activeBotCount < MaxBotsToHighlight)
         {
             ApplyHighlights();
         }
@@ -55,6 +61,7 @@ internal class CrpgDtvStuckBotHighlighter : MissionLogic
         if (_waveActive && !affectedAgent.IsPlayerControlled && affectedAgent.Team?.Side == BattleSideEnum.Attacker)
         {
             _lastAttackerBotKillTime = MissionTime.Now;
+            _highlightedAgents.Remove(affectedAgent);
             ClearHighlights();
         }
     }
@@ -75,31 +82,33 @@ internal class CrpgDtvStuckBotHighlighter : MissionLogic
 
     private void ApplyHighlights()
     {
-        _botsHighlighted = true;
         uint contourColor = new Color(1f, 0.27f, 0.27f).ToUnsignedInteger();
         foreach (Agent agent in Mission.AttackerTeam.ActiveAgents)
         {
             if (!agent.IsPlayerControlled)
             {
                 agent.AgentVisuals?.SetContourColor(contourColor);
+                _highlightedAgents.Add(agent);
             }
         }
+
+        InformationManager.DisplayMessage(new InformationMessage
+        {
+            Information = new TextObject("{=Ht7vJBcR}Remaining enemies are now highlighted!").ToString(),
+            Color = new Color(1f, 0.27f, 0.27f),
+        });
     }
 
     private void ClearHighlights()
     {
-        if (!_botsHighlighted)
+        foreach (Agent agent in _highlightedAgents)
         {
-            return;
-        }
-
-        _botsHighlighted = false;
-        foreach (Agent agent in Mission.AttackerTeam.TeamAgents)
-        {
-            if (!agent.IsPlayerControlled)
+            if (agent.IsActive())
             {
                 agent.AgentVisuals?.SetContourColor(null);
             }
         }
+
+        _highlightedAgents.Clear();
     }
 }

--- a/src/Module.Server/ModuleData/Languages/CNs/std_module_strings_xml-zho-CN.xml
+++ b/src/Module.Server/ModuleData/Languages/CNs/std_module_strings_xml-zho-CN.xml
@@ -45,6 +45,7 @@
     <string id="4HrC30kl" text="子爵已被屠杀！" />
     <string id="tdfOMWmf" text="防守者已被屠杀！" />
     <string id="mfD3LkeQ" text="子爵正遭到 {AGENT} 的攻击！" />
+    <string id="Ht7vJBcR" text="剩余的敌人已被标记！" />
     <string id="ck7dhCeM" text="欢迎 {NAMES} 加入 cRPG！" />
     <string id="FAkcpZdy" text="角色和商店" />
     <string id="xAnUFQt2" text="{COUNT} 位玩家转移到攻击方{newline}" />

--- a/src/Module.Server/ModuleData/Languages/RU/std_module_strings_xml-rus.xml
+++ b/src/Module.Server/ModuleData/Languages/RU/std_module_strings_xml-rus.xml
@@ -45,6 +45,7 @@
     <string id="4HrC30kl" text="Граф был убит!" />
     <string id="tdfOMWmf" text="Защитники были убиты!" />
     <string id="mfD3LkeQ" text="{AGENT} атаковал графа!" />
+    <string id="Ht7vJBcR" text="Оставшиеся враги теперь подсвечены!" />
     <string id="ck7dhCeM" text="Добро пожаловать, {NAMES}, кто только что {?IS_PLURAL}присоединился{?}присоединились{\?} к cRPG!" />
     <string id="FAkcpZdy" text="Персонаж и магазин" />
     <string id="xAnUFQt2" text="{COUNT} игроков перешело в команду атакующих{newline}" />


### PR DESCRIPTION
## Summary

Fix client crash (AccessViolationException) when bots are highlighted and then killed in DTV mode.

## Root Cause

`ClearHighlights` called `SetContourColor(null)` on agents whose native visuals were already invalidated by the engine. The `?.` null-conditional wasn't sufficient because `AgentVisuals` returns a non-null wrapper around an invalid native pointer.

## Changes

- **Crash fix**: Track highlighted agents in a dedicated list and guard with `agent.IsActive()` before clearing contours, matching Bannerlord's own pattern from `MissionAgentContourControllerView`
- **Bot count cap**: Only highlight when fewer than 5 bots remain
- **Notification**: Display a localized message when bots get highlighted (EN/RU/CN)

## Stack trace

```
System.AccessViolationException: Attempted to read or write protected memory.
   at ManagedCallbacks.ScriptingInterfaceOfIMBAgentVisuals.DisableContour(UIntPtr agentVisualsPtr)
   at TaleWorlds.MountAndBlade.MBAgentVisuals.SetContourColor(Nullable`1 color, Boolean alwaysVisible)
   at Crpg.Module.Modes.Dtv.CrpgDtvStuckBotHighlighter.ClearHighlights()
   at Crpg.Module.Modes.Dtv.CrpgDtvStuckBotHighlighter.OnAgentRemoved(...)
```

Fixes #643
