### PR TITLE
fix: restore siege weapon state after ammo refill

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Xml.Serialization;
 using Crpg.Module.Common;
 using Crpg.Module.Common.AiComponents;
+using Crpg.Module.Helpers;
 using Crpg.Module.Rewards;
 using NetworkMessages.FromServer;
 using TaleWorlds.Core;
@@ -456,7 +457,20 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
 
                 ammoCount = siegeWeapon.AmmoCount;
                 startingAmmoCount = siegeWeapon.StartingAmmoCount;
-                setAmmo = a => siegeWeapon.SetAmmo(a);
+                setAmmo = a =>
+                {
+                    siegeWeapon.SetAmmo(a);
+
+                    // When a weapon hits 0 ammo, it stays permanently dead. This reverses this.
+                    ReflectionHelper.SetProperty(siegeWeapon, "HasAmmo", true);
+                    siegeWeapon.SetForcedUse(true);
+                    siegeWeapon.SetIsDisabledForAI(false);
+                    var ammoPickUpPoints = (List<StandingPoint>)ReflectionHelper.GetProperty(siegeWeapon, "AmmoPickUpPoints")!;
+                    foreach (var point in ammoPickUpPoints)
+                    {
+                        point.IsDeactivated = false;
+                    }
+                };
                 createNetworkMessage = a => new SetRangedSiegeWeaponAmmo(siegeWeapon.Id, a);
             }
             else


### PR DESCRIPTION
## Problem

`CheckAmmo()` in `RangedSiegeWeapon` is a one-way gate. When ammo reaches 0, it:
- Sets `HasAmmo = false`
- Calls `SetForcedUse(false)`
- Deactivates all `AmmoPickUpPoints`

When `RefillSiegeWeaponAmmo` calls `SetAmmo(newAmmoCount)`, `CheckAmmo()` is invoked internally but only handles the `<= 0` case. It never restores `HasAmmo`, re-activates pickup points, or clears the AI disable flag.

The tick loop then sees `!HasAmmo` and calls `SetIsDisabledForAI(true)` + early returns, and `GetDetachmentWeightAux` returns `float.MinValue` -- the weapon is permanently dead.

## Fix

In the `setAmmo` lambda for `RangedSiegeWeapon`, after calling `SetAmmo()`, restore the weapon state:
- `HasAmmo = true` (via ReflectionHelper -- protected virtual)
- `SetForcedUse(true)`
- `SetIsDisabledForAI(false)`
- Re-activate all `AmmoPickUpPoints`
