### PR TITLE
refactor: pass GameMode explicitly from game server instead of deriving from Instance alias

### DIFF
--- a/src/Application/Games/Commands/GetGameUserCommand.cs
+++ b/src/Application/Games/Commands/GetGameUserCommand.cs
@@ -26,6 +26,7 @@ public record GetGameUserCommand : IMediatorRequest<GameUserViewModel>
     public Platform Platform { get; init; }
     public string PlatformUserId { get; init; } = default!;
     public Region Region { get; init; }
+    public GameMode GameMode { get; init; }
     public string Instance { get; init; } = string.Empty;
 
     public class Validator : AbstractValidator<GetGameUserCommand>
@@ -137,11 +138,10 @@ public record GetGameUserCommand : IMediatorRequest<GameUserViewModel>
         private readonly IUserService _userService;
         private readonly ICharacterService _characterService;
         private readonly IActivityLogService _activityLogService;
-        private readonly IGameModeService _gameModeService;
 
         public Handler(ICrpgDbContext db, IMapper mapper, IDateTime dateTime,
             IRandom random, IUserService userService, ICharacterService characterService,
-            IActivityLogService activityLogService, IGameModeService gameModeService)
+            IActivityLogService activityLogService)
         {
             _db = db;
             _mapper = mapper;
@@ -150,7 +150,6 @@ public record GetGameUserCommand : IMediatorRequest<GameUserViewModel>
             _userService = userService;
             _characterService = characterService;
             _activityLogService = activityLogService;
-            _gameModeService = gameModeService;
         }
 
         public async ValueTask<Result<GameUserViewModel>> Handle(GetGameUserCommand req, CancellationToken cancellationToken)
@@ -216,7 +215,7 @@ public record GetGameUserCommand : IMediatorRequest<GameUserViewModel>
                     .Include(ei => ei.UserItem)
                     .LoadAsync(cancellationToken);
 
-                GameMode currentGameMode = _gameModeService.GameModeByInstanceAlias(Enum.TryParse(req.Instance[^1..], ignoreCase: true, out GameModeAlias instanceAlias) ? instanceAlias : GameModeAlias.Z);
+                GameMode currentGameMode = req.GameMode;
 
                 var statistics = await _db.Entry(user.ActiveCharacter)
                     .Collection(c => c.Statistics)

--- a/src/Application/Games/Commands/UpdateGameUsersCommand.cs
+++ b/src/Application/Games/Commands/UpdateGameUsersCommand.cs
@@ -32,15 +32,13 @@ public record UpdateGameUsersCommand : IMediatorRequest<UpdateGameUsersResult>
         private readonly IMapper _mapper;
         private readonly ICharacterService _characterService;
         private readonly IActivityLogService _activityLogService;
-        private readonly IGameModeService _gameModeService;
 
-        public Handler(ICrpgDbContext db, IMapper mapper, ICharacterService characterService, IActivityLogService activityLogService, IGameModeService gameModeService)
+        public Handler(ICrpgDbContext db, IMapper mapper, ICharacterService characterService, IActivityLogService activityLogService)
         {
             _db = db;
             _mapper = mapper;
             _characterService = characterService;
             _activityLogService = activityLogService;
-            _gameModeService = gameModeService;
         }
 
         public async ValueTask<Result<UpdateGameUsersResult>> Handle(UpdateGameUsersCommand req,
@@ -77,7 +75,7 @@ public record UpdateGameUsersCommand : IMediatorRequest<UpdateGameUsersResult>
             List<(User user, GameUserEffectiveReward reward, List<GameRepairedItem> repairedItems, GameMode gameMode)> results = new(req.Updates.Count);
             foreach (var update in req.Updates)
             {
-                GameMode updateGameMode = _gameModeService.GameModeByInstanceAlias(Enum.TryParse(update.Instance[^1..], ignoreCase: true, out GameModeAlias instanceAlias) ? instanceAlias : GameModeAlias.Z);
+                GameMode updateGameMode = update.GameMode;
                 if (!charactersById.TryGetValue(update.CharacterId, out Character? character))
                 {
                     Logger.LogWarning("Character with id '{0}' doesn't exist", update.CharacterId);

--- a/src/Application/Games/Models/GameUserUpdate.cs
+++ b/src/Application/Games/Models/GameUserUpdate.cs
@@ -1,4 +1,5 @@
 ﻿using Crpg.Application.Characters.Models;
+using Crpg.Domain.Entities.Servers;
 
 namespace Crpg.Application.Games.Models;
 
@@ -9,5 +10,6 @@ public record GameUserUpdate
     public GameUserReward Reward { get; init; } = new();
     public CharacterStatisticsViewModel Statistics { get; init; } = new();
     public IList<GameUserDamagedItem> BrokenItems { get; init; } = Array.Empty<GameUserDamagedItem>();
+    public GameMode GameMode { get; init; }
     public string Instance { get; init; } = string.Empty;
 }

--- a/src/Module.Server/Api/HttpCrpgClient.cs
+++ b/src/Module.Server/Api/HttpCrpgClient.cs
@@ -65,7 +65,7 @@ internal class HttpCrpgClient : ICrpgClient
         };
     }
 
-    public Task<CrpgResult<CrpgUser>> GetUserAsync(Platform platform, string platformUserId, CrpgRegion region,
+    public Task<CrpgResult<CrpgUser>> GetUserAsync(Platform platform, string platformUserId, CrpgRegion region, CrpgGameMode gameMode,
         CancellationToken cancellationToken = default)
     {
         Dictionary<string, string> queryParameters = new(StringComparer.Ordinal)
@@ -73,6 +73,7 @@ internal class HttpCrpgClient : ICrpgClient
             ["platform"] = platform.ToString(),
             ["platformUserId"] = platformUserId,
             ["region"] = region.ToString(),
+            ["gameMode"] = gameMode.ToString(),
             ["instance"] = CrpgServerConfiguration.Instance.ToString(),
         };
         return Get<CrpgUser>("games/users", queryParameters, cancellationToken);

--- a/src/Module.Server/Api/ICrpgClient.cs
+++ b/src/Module.Server/Api/ICrpgClient.cs
@@ -8,7 +8,7 @@ namespace Crpg.Module.Api;
 
 internal interface ICrpgClient : IDisposable
 {
-    Task<CrpgResult<CrpgUser>> GetUserAsync(Platform platform, string platformUserId, CrpgRegion region,
+    Task<CrpgResult<CrpgUser>> GetUserAsync(Platform platform, string platformUserId, CrpgRegion region, CrpgGameMode gameMode,
         CancellationToken cancellationToken = default);
 
     Task<CrpgResult<CrpgUser>> GetTournamentUserAsync(Platform platform, string platformUserId,

--- a/src/Module.Server/Api/Models/CrpgGameMode.cs
+++ b/src/Module.Server/Api/Models/CrpgGameMode.cs
@@ -1,0 +1,14 @@
+namespace Crpg.Module.Api.Models;
+
+internal enum CrpgGameMode
+{
+    CRPGBattle,
+    CRPGConquest,
+    CRPGDTV,
+    CRPGDuel,
+    CRPGSiege,
+    CRPGTeamDeathmatch,
+    CRPGSkirmish,
+    CRPGUnknownGameMode,
+    CRPGCaptain,
+}

--- a/src/Module.Server/Api/Models/CrpgUserUpdate.cs
+++ b/src/Module.Server/Api/Models/CrpgUserUpdate.cs
@@ -10,5 +10,6 @@ internal class CrpgUserUpdate
     public CrpgUserReward? Reward { get; set; }
     public CrpgCharacterStatistics Statistics { get; set; } = null!;
     public IList<CrpgUserDamagedItem> BrokenItems { get; set; } = Array.Empty<CrpgUserDamagedItem>();
+    public CrpgGameMode GameMode { get; set; }
     public string Instance { get; set; } = string.Empty;
 }

--- a/src/Module.Server/Api/StubCrpgClient.cs
+++ b/src/Module.Server/Api/StubCrpgClient.cs
@@ -15,7 +15,7 @@ internal class StubCrpgClient : ICrpgClient
 {
     private static readonly Random Random = new();
 
-    public Task<CrpgResult<CrpgUser>> GetUserAsync(Platform platform, string platformUserId, CrpgRegion region,
+    public Task<CrpgResult<CrpgUser>> GetUserAsync(Platform platform, string platformUserId, CrpgRegion region, CrpgGameMode gameMode,
         CancellationToken cancellationToken = default)
     {
         CrpgUser user = new()
@@ -99,7 +99,7 @@ internal class StubCrpgClient : ICrpgClient
 
     public Task<CrpgResult<CrpgUser>> GetTournamentUserAsync(Platform platform, string platformUserId, CancellationToken cancellationToken = default)
     {
-        return GetUserAsync(platform, platformUserId, CrpgRegion.Eu, cancellationToken: cancellationToken);
+        return GetUserAsync(platform, platformUserId, CrpgRegion.Eu, CrpgGameMode.CRPGUnknownGameMode, cancellationToken: cancellationToken);
     }
 
     public Task CreateActivityLogsAsync(IList<CrpgActivityLog> activityLogs, CancellationToken cancellationToken = default)

--- a/src/Module.Server/Common/CrpgUserManagerServer.cs
+++ b/src/Module.Server/Common/CrpgUserManagerServer.cs
@@ -26,12 +26,14 @@ internal class CrpgUserManagerServer : MissionNetwork
 
     private readonly ICrpgClient _crpgClient;
     private readonly CrpgConstants _constants;
+    private readonly CrpgGameMode _gameMode;
     private readonly Dictionary<int, Task<CrpgResult<CrpgClan>>> _clanTasks;
 
-    public CrpgUserManagerServer(ICrpgClient crpgClient, CrpgConstants constants)
+    public CrpgUserManagerServer(ICrpgClient crpgClient, CrpgConstants constants, CrpgGameMode gameMode)
     {
         _crpgClient = crpgClient;
         _constants = constants;
+        _gameMode = gameMode;
         _clanTasks = new Dictionary<int, Task<CrpgResult<CrpgClan>>>();
     }
 
@@ -182,7 +184,7 @@ internal class CrpgUserManagerServer : MissionNetwork
         {
             var userRes = CrpgFeatureFlags.IsEnabled(CrpgFeatureFlags.FeatureTournament)
                 ? await _crpgClient.GetTournamentUserAsync(platform, platformUserId)
-                : await _crpgClient.GetUserAsync(platform, platformUserId, CrpgServerConfiguration.Region);
+                : await _crpgClient.GetUserAsync(platform, platformUserId, CrpgServerConfiguration.Region, _gameMode);
             crpgUser = userRes.Data!;
 
             if (crpgUser.ClanMembership != null)

--- a/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
@@ -1,5 +1,6 @@
 #if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 #else
 using Crpg.Module.GUI;
@@ -129,7 +130,14 @@ internal class CrpgBattleGameMode : MissionBasedMultiplayerGameMode
         CrpgWarmupComponent warmupComponent = new(_constants, () =>
             (new FlagDominationSpawnFrameBehavior(), spawningBehavior));
         CrpgTeamSelectServerComponent teamSelectComponent = new(warmupComponent, roundController, _gameType);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true, enableRating: true);
+        CrpgGameMode crpgGameMode = _gameType switch
+        {
+            MultiplayerGameType.Battle => CrpgGameMode.CRPGBattle,
+            MultiplayerGameType.Skirmish => CrpgGameMode.CRPGSkirmish,
+            MultiplayerGameType.Captain => CrpgGameMode.CRPGCaptain,
+            _ => CrpgGameMode.CRPGUnknownGameMode,
+        };
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true, enableRating: true, gameMode: crpgGameMode);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, null);
         CrpgTeamSelectClientComponent teamSelectComponent = new();
@@ -184,7 +192,7 @@ internal class CrpgBattleGameMode : MissionBasedMultiplayerGameMode
                     new SpawnComponent(new BattleSpawnFrameBehavior(), spawningBehavior),
                     new AgentHumanAILogic(), // bot intelligence
                     new MultiplayerAdminComponent(), // admin UI to kick player or restart game
-                    new CrpgUserManagerServer(crpgClient, _constants),
+                    new CrpgUserManagerServer(crpgClient, _constants, crpgGameMode),
                     new KickInactiveBehavior(inactiveTimeLimit: 30, warmupComponent, teamSelectComponent),
                     new MapPoolComponent(),
                     new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),

--- a/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
@@ -1,5 +1,6 @@
 ﻿#if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 using Crpg.Module.Modes.Siege;
 #else
@@ -97,7 +98,7 @@ internal class CrpgConquestGameMode : MissionBasedMultiplayerGameMode
         CrpgWarmupComponent warmupComponent = new(_constants,
             () => (new SiegeSpawnFrameBehavior(), new CrpgSiegeSpawningBehavior(_constants)));
         CrpgTeamSelectServerComponent teamSelectComponent = new(warmupComponent, null, MultiplayerGameType.Siege);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false, gameMode: CrpgGameMode.CRPGConquest);
         CrpgConquestServer conquestServer = new(scoreboardComponent, rewardServer);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, null);
@@ -143,7 +144,7 @@ internal class CrpgConquestGameMode : MissionBasedMultiplayerGameMode
                 conquestServer,
                 rewardServer,
                 new SpawnComponent(new SiegeSpawnFrameBehavior(), spawnBehavior),
-                new CrpgUserManagerServer(crpgClient, _constants),
+                new CrpgUserManagerServer(crpgClient, _constants, CrpgGameMode.CRPGConquest),
                 new KickInactiveBehavior(inactiveTimeLimit: 90, warmupComponent, teamSelectComponent),
                 new MapPoolComponent(),
                 new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),

--- a/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
@@ -1,5 +1,6 @@
 #if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 #else
 using Crpg.Module.Common.HotConstants;
@@ -100,7 +101,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
             (new FlagDominationSpawnFrameBehavior(),
             new CrpgDtvSpawningBehavior(_constants)));
         CrpgTeamSelectServerComponent teamSelectComponent = new(warmupComponent, null, MultiplayerGameType.Siege);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true, enableRating: false, enableLowPopulationUpkeep: true);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true, enableRating: false, gameMode: CrpgGameMode.CRPGDTV, enableLowPopulationUpkeep: true);
         CrpgDtvSpawningBehavior spawnBehaviour = new(_constants);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, null);
@@ -147,7 +148,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
                 new SpawnComponent(new BattleSpawnFrameBehavior(), spawnBehaviour),
                 new AgentHumanAILogic(), // bot intelligence
                 new MultiplayerAdminComponent(), // admin UI to kick player or restart game
-                new CrpgUserManagerServer(crpgClient, _constants),
+                new CrpgUserManagerServer(crpgClient, _constants, CrpgGameMode.CRPGDTV),
                 new KickInactiveBehavior(inactiveTimeLimit: 120, warmupComponent),
                 new MapPoolComponent(),
                 new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),

--- a/src/Module.Server/Modes/Duel/CrpgDuelGameMode.cs
+++ b/src/Module.Server/Modes/Duel/CrpgDuelGameMode.cs
@@ -1,5 +1,6 @@
 ﻿#if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 using Crpg.Module.Rewards;
 #else
@@ -79,7 +80,7 @@ internal class CrpgDuelGameMode : MissionBasedMultiplayerGameMode
         ICrpgClient crpgClient = CrpgClient.Create();
         Game.Current.GetGameHandler<ChatCommandsComponent>()?.InitChatCommands(crpgClient);
         ChatBox chatBox = Game.Current.GetGameHandler<ChatBox>();
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, null, enableTeamHitCompensations: false, enableRating: true);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, null, enableTeamHitCompensations: false, enableRating: true, gameMode: CrpgGameMode.CRPGDuel);
         CrpgDuelServer duelServer = new(rewardServer);
 #endif
         CrpgDuelMissionMultiplayerClient duelClient = new();
@@ -117,7 +118,7 @@ internal class CrpgDuelGameMode : MissionBasedMultiplayerGameMode
                     new MissionAgentPanicHandler(),
                     new AgentHumanAILogic(), // bot intelligence
                     new EquipmentControllerLeaveLogic(),
-                    new CrpgUserManagerServer(crpgClient, _constants),
+                    new CrpgUserManagerServer(crpgClient, _constants, CrpgGameMode.CRPGDuel),
                     new CrpgActivityLogsBehavior(null, chatBox, crpgClient),
                     new ServerMetricsBehavior(),
                     new NotAllPlayersReadyComponent(),

--- a/src/Module.Server/Modes/Siege/CrpgSiegeGameMode.cs
+++ b/src/Module.Server/Modes/Siege/CrpgSiegeGameMode.cs
@@ -1,5 +1,6 @@
 #if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 #else
 using Crpg.Module.GUI;
@@ -85,7 +86,7 @@ internal class CrpgSiegeGameMode : MissionBasedMultiplayerGameMode
         ChatBox chatBox = Game.Current.GetGameHandler<ChatBox>();
         CrpgWarmupComponent warmupComponent = new(_constants,
             () => (new SiegeSpawnFrameBehavior(), new CrpgSiegeSpawningBehavior(_constants)));
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false, gameMode: CrpgGameMode.CRPGConquest);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, null);
 #endif
@@ -123,7 +124,7 @@ internal class CrpgSiegeGameMode : MissionBasedMultiplayerGameMode
 
 #if CRPG_SERVER
                 new CrpgSiegeServer(siegeClient, scoreboardComponent, rewardServer),
-                new CrpgUserManagerServer(crpgClient, _constants),
+                new CrpgUserManagerServer(crpgClient, _constants, CrpgGameMode.CRPGConquest),
                 new KickInactiveBehavior(inactiveTimeLimit: 90, warmupComponent),
                 new MapPoolComponent(),
                 new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
@@ -1,5 +1,6 @@
 #if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 #else
 
@@ -100,7 +101,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
         CrpgWarmupComponent warmupComponent = new(_constants,
             () => (new CrpgTeamDeathmatchSpawnFrameBehavior(), new CrpgTeamDeathmatchSpawningBehavior(_constants)));
         CrpgTeamSelectServerComponent teamSelectComponent = new(warmupComponent, null, MultiplayerGameType.TeamDeathmatch);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: true);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: true, gameMode: CrpgGameMode.CRPGTeamDeathmatch);
         CrpgTeamDeathmatchServer teamDeathmatchServer = new(scoreboardComponent, rewardServer);
 
 #else
@@ -147,7 +148,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
                 new SpawnComponent(new CrpgTeamDeathmatchSpawnFrameBehavior(), spawnBehavior),
                 new AgentHumanAILogic(),
                 new MultiplayerAdminComponent(),
-                new CrpgUserManagerServer(crpgClient, _constants),
+                new CrpgUserManagerServer(crpgClient, _constants, CrpgGameMode.CRPGTeamDeathmatch),
                 new KickInactiveBehavior(inactiveTimeLimit: 30, warmupComponent, teamSelectComponent),
                 new MapPoolComponent(),
                 new CrpgActivityLogsBehavior(warmupComponent, chatBox, crpgClient),

--- a/src/Module.Server/Modes/TrainingGround/CrpgTrainingGroundGameMode.cs
+++ b/src/Module.Server/Modes/TrainingGround/CrpgTrainingGroundGameMode.cs
@@ -1,5 +1,6 @@
 ﻿#if CRPG_SERVER
 using Crpg.Module.Api;
+using Crpg.Module.Api.Models;
 using Crpg.Module.Common.ChatCommands;
 #endif
 using Crpg.Module.Common;
@@ -81,7 +82,7 @@ internal class CrpgTrainingGroundGameMode : MissionBasedMultiplayerGameMode
         ICrpgClient crpgClient = CrpgClient.Create();
         Game.Current.GetGameHandler<ChatCommandsComponent>()?.InitChatCommands(crpgClient);
         ChatBox chatBox = Game.Current.GetGameHandler<ChatBox>();
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, null, enableTeamHitCompensations: false, enableRating: false, enableLowPopulationUpkeep: true);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, null, enableTeamHitCompensations: false, enableRating: false, gameMode: CrpgGameMode.CRPGDuel, enableLowPopulationUpkeep: true);
         CrpgTrainingGroundServer duelServer = new(rewardServer);
 #endif
         CrpgTrainingGroundMissionMultiplayerClient duelClient = new();
@@ -120,7 +121,7 @@ internal class CrpgTrainingGroundGameMode : MissionBasedMultiplayerGameMode
                     new MissionAgentPanicHandler(),
                     new AgentHumanAILogic(), // bot intelligence
                     new EquipmentControllerLeaveLogic(),
-                    new CrpgUserManagerServer(crpgClient, _constants),
+                    new CrpgUserManagerServer(crpgClient, _constants, CrpgGameMode.CRPGDuel),
                     new CrpgActivityLogsBehavior(null, chatBox, crpgClient),
                     new ServerMetricsBehavior(),
                     new NotAllPlayersReadyComponent(),

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -36,6 +36,7 @@ internal class CrpgRewardServer : MissionLogic
     private readonly bool _isTeamHitCompensationsEnabled;
     private readonly bool _isRatingEnabled;
     private readonly bool _isLowPopulationUpkeepEnabled;
+    private readonly CrpgGameMode _gameMode;
 
     private bool _lastRewardDuringHappyHours;
 
@@ -45,6 +46,7 @@ internal class CrpgRewardServer : MissionLogic
         CrpgWarmupComponent? warmupComponent,
         bool enableTeamHitCompensations,
         bool enableRating,
+        CrpgGameMode gameMode,
         bool enableLowPopulationUpkeep = false)
     {
         _crpgClient = crpgClient;
@@ -59,6 +61,7 @@ internal class CrpgRewardServer : MissionLogic
         _isTeamHitCompensationsEnabled = enableTeamHitCompensations;
         _isRatingEnabled = enableRating;
         _isLowPopulationUpkeepEnabled = enableLowPopulationUpkeep;
+        _gameMode = gameMode;
     }
 
     public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
@@ -153,6 +156,7 @@ internal class CrpgRewardServer : MissionLogic
                 Rating = winnerStats.Rating,
             },
             BrokenItems = Array.Empty<CrpgUserDamagedItem>(),
+            GameMode = _gameMode,
             Instance = CrpgServerConfiguration.Instance,
         };
         crpgPeerByCrpgUserId[winnerUpdate.UserId] = winnerPeer;
@@ -174,6 +178,7 @@ internal class CrpgRewardServer : MissionLogic
                 Rating = loserStats.Rating,
             },
             BrokenItems = Array.Empty<CrpgUserDamagedItem>(),
+            GameMode = _gameMode,
             Instance = CrpgServerConfiguration.Instance,
         };
         crpgPeerByCrpgUserId[loserUpdate.UserId] = loserPeer;
@@ -296,6 +301,7 @@ internal class CrpgRewardServer : MissionLogic
                     Rating = crpgPeer.User.Character.Statistics.Rating,
                 },
                 BrokenItems = Array.Empty<CrpgUserDamagedItem>(),
+                GameMode = _gameMode,
                 Instance = CrpgServerConfiguration.Instance,
             };
 

--- a/src/WebApi/Controllers/GamesController.cs
+++ b/src/WebApi/Controllers/GamesController.cs
@@ -8,6 +8,7 @@ using Crpg.Application.Games.Models;
 using Crpg.Application.Restrictions.Commands;
 using Crpg.Application.Restrictions.Models;
 using Crpg.Domain.Entities;
+using Crpg.Domain.Entities.Servers;
 using Crpg.Domain.Entities.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -22,12 +23,13 @@ public class GamesController : BaseController
     /// </summary>
     [HttpGet("users")]
     public Task<ActionResult<Result<GameUserViewModel>>> GetUser(
-        [FromQuery] Platform platform, [FromQuery] string platformUserId, [FromQuery] Region region, [FromQuery] string instance) =>
+        [FromQuery] Platform platform, [FromQuery] string platformUserId, [FromQuery] Region region, [FromQuery] GameMode gameMode, [FromQuery] string instance) =>
         ResultToActionAsync(Mediator.Send(new GetGameUserCommand
         {
             Platform = platform,
             PlatformUserId = platformUserId,
             Region = region,
+            GameMode = gameMode,
             Instance = instance,
         }));
 

--- a/test/Application.UTest/Games/GetGameUserCommandTest.cs
+++ b/test/Application.UTest/Games/GetGameUserCommandTest.cs
@@ -1,4 +1,4 @@
-﻿using Crpg.Application.Common.Files;
+using Crpg.Application.Common.Files;
 using Crpg.Application.Common.Results;
 using Crpg.Application.Common.Services;
 using Crpg.Application.Games.Commands;
@@ -45,10 +45,9 @@ public class GetGameUserCommandTest : TestBase
         Mock<IUserService> userServiceMock = new();
         Mock<ICharacterService> characterServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper, new MachineDateTime(),
-            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -81,10 +80,9 @@ public class GetGameUserCommandTest : TestBase
         Mock<IUserService> userServiceMock = new();
         Mock<ICharacterService> characterServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper, new MachineDateTime(),
-            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -121,7 +119,6 @@ public class GetGameUserCommandTest : TestBase
         Mock<IUserService> userServiceMock = new();
         Mock<ICharacterService> characterServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         User user = new()
         {
@@ -138,7 +135,7 @@ public class GetGameUserCommandTest : TestBase
         await ArrangeDb.SaveChangesAsync();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper, new MachineDateTime(),
-            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -179,7 +176,6 @@ public class GetGameUserCommandTest : TestBase
         Mock<IUserService> userServiceMock = new();
         Mock<ICharacterService> characterServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         User user = new()
         {
@@ -200,7 +196,7 @@ public class GetGameUserCommandTest : TestBase
         await ArrangeDb.SaveChangesAsync();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper, new MachineDateTime(),
-            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            new ThreadSafeRandom(), userServiceMock.Object, characterServiceMock.Object, activityLogServiceMock.Object);
 
         var res = await handler.Handle(new GetGameUserCommand
         {
@@ -220,7 +216,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         User user = new()
         {
@@ -242,7 +237,7 @@ public class GetGameUserCommandTest : TestBase
         randomMock.Setup(r => r.Next(It.IsAny<int>(), It.IsAny<int>())).Returns(1);
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            new MachineDateTime(), randomMock.Object, userService, characterService, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            new MachineDateTime(), randomMock.Object, userService, characterService, activityLogServiceMock.Object);
 
         // Handle shouldn't throw
         await handler.Handle(new GetGameUserCommand
@@ -263,7 +258,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         var activityLogService = Mock.Of<IActivityLogService>();
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         Character user0Character = new();
         User user0 = new()
@@ -289,7 +283,7 @@ public class GetGameUserCommandTest : TestBase
         await ArrangeDb.SaveChangesAsync();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService, gameModeServiceMock.Object);
+            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -311,7 +305,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         var activityLogService = Mock.Of<IActivityLogService>();
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         Character character = new();
         User user = new()
@@ -331,7 +324,7 @@ public class GetGameUserCommandTest : TestBase
         await ArrangeDb.SaveChangesAsync();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService, gameModeServiceMock.Object);
+            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -351,7 +344,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         User user = new()
         {
@@ -395,7 +387,7 @@ public class GetGameUserCommandTest : TestBase
             .Returns(new DateTime(2000, 1, 1, 12, 0, 0));
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            dateTime.Object, new ThreadSafeRandom(), userService, characterService, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            dateTime.Object, new ThreadSafeRandom(), userService, characterService, activityLogServiceMock.Object);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -415,7 +407,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         User user = new()
         {
@@ -457,7 +448,7 @@ public class GetGameUserCommandTest : TestBase
             .Returns(new DateTime(2000, 1, 1, 12, 0, 0));
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            dateTime.Object, new ThreadSafeRandom(), userService, characterService, activityLogServiceMock.Object, gameModeServiceMock.Object);
+            dateTime.Object, new ThreadSafeRandom(), userService, characterService, activityLogServiceMock.Object);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -529,7 +520,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         var activityLogService = Mock.Of<IActivityLogService>();
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         Character character = new()
         {
@@ -574,7 +564,7 @@ public class GetGameUserCommandTest : TestBase
         await ArrangeDb.SaveChangesAsync();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService, gameModeServiceMock.Object);
+            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService);
 
         var result = await handler.Handle(new GetGameUserCommand
         {
@@ -595,7 +585,6 @@ public class GetGameUserCommandTest : TestBase
         var userService = Mock.Of<IUserService>();
         var characterService = Mock.Of<ICharacterService>();
         var activityLogService = Mock.Of<IActivityLogService>();
-        Mock<IGameModeService> gameModeServiceMock = new();
 
         Character character = new();
         User user = new()
@@ -613,7 +602,7 @@ public class GetGameUserCommandTest : TestBase
         await ArrangeDb.SaveChangesAsync();
 
         GetGameUserCommand.Handler handler = new(ActDb, Mapper,
-            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService, gameModeServiceMock.Object);
+            new MachineDateTime(), new ThreadSafeRandom(), userService, characterService, activityLogService);
 
         var result = await handler.Handle(new GetGameUserCommand
         {

--- a/test/Application.UTest/Games/UpdateGameUsersCommandTest.cs
+++ b/test/Application.UTest/Games/UpdateGameUsersCommandTest.cs
@@ -21,9 +21,8 @@ public class UpdateGameUsersCommandTest : TestBase
     public void ShouldDoNothingForEmptyUpdates()
     {
         Mock<ICharacterService> characterServiceMock = new();
-        Mock<IGameModeService> gameModeServiceServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceServiceMock.Object);
+        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object);
         Assert.That(() => handler.Handle(new UpdateGameUsersCommand(), CancellationToken.None), Throws.Nothing);
     }
 
@@ -94,9 +93,8 @@ public class UpdateGameUsersCommandTest : TestBase
             .Setup(cs => cs.UpdateRating(It.IsAny<Character>(), GameMode.CRPGBattle, 4, 5, 6, true));
 
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceServiceMock = new();
 
-        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceServiceMock.Object);
+        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object);
         var result = await handler.Handle(new UpdateGameUsersCommand
         {
             Updates =
@@ -122,7 +120,7 @@ public class UpdateGameUsersCommandTest : TestBase
                             Volatility = 6,
                         },
                     },
-                    Instance = "crpg01a",
+                    GameMode = GameMode.CRPGBattle,
                     BrokenItems =
                     [
                         new GameUserDamagedItem { UserItemId = user.Characters[0].EquippedItems[0].UserItemId, RepairCost = 30 }
@@ -155,8 +153,6 @@ public class UpdateGameUsersCommandTest : TestBase
 
         characterServiceMock.VerifyAll();
 
-        gameModeServiceServiceMock.Verify(m =>
-            m.GameModeByInstanceAlias(It.IsAny<GameModeAlias>()), Times.Once);
         activityLogServiceMock.Verify(m =>
             m.CreateCharacterEarnedLog(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<GameMode>(), It.IsAny<int>(), It.Is<int>(x => x == 200 - 30), It.IsAny<double>()), Times.Once);
     }
@@ -196,16 +192,15 @@ public class UpdateGameUsersCommandTest : TestBase
         Mock<ICharacterService> characterServiceMock = new();
 
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceServiceMock = new();
 
-        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceServiceMock.Object);
+        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object);
         var result = await handler.Handle(new UpdateGameUsersCommand
         {
             Updates =
             [
                 new GameUserUpdate
                 {
-                    Instance = "crpg99a",
+                    GameMode = GameMode.CRPGBattle,
                     CharacterId = user.Characters[0].Id,
                     BrokenItems =
                     [
@@ -288,16 +283,15 @@ public class UpdateGameUsersCommandTest : TestBase
         Mock<ICharacterService> characterServiceMock = new();
 
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceServiceMock = new();
 
-        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceServiceMock.Object);
+        UpdateGameUsersCommand.Handler handler = new(ActDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object);
         var result = await handler.Handle(new UpdateGameUsersCommand
         {
             Updates =
             [
                 new GameUserUpdate
                 {
-                    Instance = "crpg99a",
+                    GameMode = GameMode.CRPGBattle,
                     CharacterId = user.Characters[0].Id,
                     BrokenItems =
                     [
@@ -366,9 +360,8 @@ public class UpdateGameUsersCommandTest : TestBase
 
         Mock<ICharacterService> characterServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceServiceMock = new();
 
-        UpdateGameUsersCommand.Handler handler = new(failingDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceServiceMock.Object);
+        UpdateGameUsersCommand.Handler handler = new(failingDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object);
         var result = await handler.Handle(new UpdateGameUsersCommand
         {
             Updates =
@@ -381,7 +374,7 @@ public class UpdateGameUsersCommandTest : TestBase
                     {
                         Rating = new CharacterRatingViewModel(),
                     },
-                    Instance = "crpg01a",
+                    GameMode = GameMode.CRPGBattle,
                     BrokenItems = [],
                 }
             ],
@@ -423,9 +416,8 @@ public class UpdateGameUsersCommandTest : TestBase
 
         Mock<ICharacterService> characterServiceMock = new();
         Mock<IActivityLogService> activityLogServiceMock = new() { DefaultValue = DefaultValue.Mock };
-        Mock<IGameModeService> gameModeServiceServiceMock = new();
 
-        UpdateGameUsersCommand.Handler handler = new(failingDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object, gameModeServiceServiceMock.Object);
+        UpdateGameUsersCommand.Handler handler = new(failingDb, Mapper, characterServiceMock.Object, activityLogServiceMock.Object);
 
         Assert.ThrowsAsync<ConflictException>(async () =>
             await handler.Handle(new UpdateGameUsersCommand
@@ -440,7 +432,7 @@ public class UpdateGameUsersCommandTest : TestBase
                         {
                             Rating = new CharacterRatingViewModel(),
                         },
-                        Instance = "crpg01a",
+                        GameMode = GameMode.CRPGBattle,
                         BrokenItems = [],
                     }
                 ],


### PR DESCRIPTION
Replace `GameModeByInstanceAlias` lookup with explicit `GameMode` field in API requests.