### PR TITLE
fix: training ground SIGSEGV crash on duel end (agent team desync)

### DIFF
--- a/src/Module.Server/Modes/TrainingGround/CrpgTrainingGroundServer.cs
+++ b/src/Module.Server/Modes/TrainingGround/CrpgTrainingGroundServer.cs
@@ -61,6 +61,10 @@ internal class CrpgTrainingGroundServer : MissionMultiplayerGameModeBase
             {
                 if (MissionPeer.Peer.Communicator.IsConnectionActive)
                 {
+                    // Both calls are needed: SetTeam updates the native agent's team,
+                    // MissionPeer.Team updates the peer's team. Omitting SetTeam causes
+                    // a desync that crashes in Agent::compute_body_rotation.
+                    MissionPeer.ControlledAgent?.SetTeam(Mission.Current.AttackerTeam, true);
                     MissionPeer.Team = Mission.Current.AttackerTeam;
                 }
             }


### PR DESCRIPTION
## Problem

Repeated SIGSEGV crashes on **crpg03 server c** (Training Ground mode). Both crashes have identical native stack traces:

```
Agent::compute_body_rotation(float)
Agent::movement_and_dynamics_system_related_tick(...)
Mission::handle_agent_movement_and_dynamics_system_related_ticks(...)
Mission::tick(float)
```

Crashes occur **within 1-2ms** of duel-end team changes:
```
06:02:02.279  Set the team to: Attacker, for peer: ...
06:02:02.280  SIGSEGV (signal 11)
```

## Root Cause

In `DuelInfo.Challenger.OnDuelEnded()`, only `MissionPeer.Team` was set to `AttackerTeam`. The **agent's native team was never updated** -- it stayed on the Defender (duel) team. This peer/agent team desync caused the engine's physics tick to access inconsistent internal state, crashing in `compute_body_rotation`.

Compare with `OnDuelPreparation()` which correctly updates **both**:
```csharp
// OnDuelPreparation -- correct
agent.SetTeam(duelingTeam, true);    // agent team updated
MissionPeer.Team = duelingTeam;      // peer team updated

// OnDuelEnded -- was missing agent.SetTeam()
MissionPeer.Team = AttackerTeam;     // only peer team updated (BUG)
```

The native `ChangeTeamServer` also expects consistency -- it kills the agent before changing the peer's team to prevent exactly this kind of desync.

## Fix

Call `agent.SetTeam(AttackerTeam, true)` before setting `MissionPeer.Team` in `OnDuelEnded()`, mirroring the pattern already used in `OnDuelPreparation()`.
