### PR TITLE
fix: use unix socket for datadog postgres check

### DIFF
--- a/deploy/group_vars/centralservers.yml
+++ b/deploy/group_vars/centralservers.yml
@@ -71,7 +71,7 @@ datadog_checks:
     postgres:
         init_config:
         instances:
-            - host: localhost
+            - host: /var/run/postgresql
               port: 5432
               dbname: "{{ crpg_db }}"
               username: "{{ datadog_db_user }}"


### PR DESCRIPTION
The Datadog postgres check was connecting via TCP (\`localhost\`/\`127.0.0.1\`) which requires md5 password auth per \`pg_hba.conf\`. The \`dd-agent\` user has no password and relies on peer authentication, which only works over Unix sockets.