### PR TITLE
fix: skip morale boost on single-flag maps

### DIFF
--- a/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
@@ -307,7 +307,8 @@ internal class CrpgBattleServer : MissionMultiplayerGameModeBase
         float moraleGain = teamFlagsDelta <= 0
             ? MBMath.ClampFloat(-1 - _morale, -2f, -1f) * moraleMultiplier
             : MBMath.ClampFloat(1 - _morale, 1f, 2f) * moraleMultiplier;
-        if (_flagSystem.HasFlagCountChanged()) // For the last flag, the morale is moving faster.
+        // For the last flag on multi-flag maps, the morale is moving faster.
+        if (_flagSystem.HasFlagCountChanged() && _flagSystem.GetAllFlags().Length > 1)
         {
             moraleGain *= moraleGainMultiplierLastFlag;
         }


### PR DESCRIPTION
The 2x morale multiplier was applied whenever the flag manipulation phase triggered, even on maps with only one flag. Now the multiplier only applies when the map has more than one flag point.