### PR TITLE
fix: remove morale multiplier for battle single-flag system

### DIFF
--- a/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleServer.cs
@@ -16,7 +16,6 @@ namespace Crpg.Module.Modes.Battle;
 internal class CrpgBattleServer : MissionMultiplayerGameModeBase
 {
     private const float BattleMoraleGainOnTick = 0.01f;
-    private const float BattleMoraleGainMultiplierLastFlag = 2f;
     private const float SkirmishMoraleGainOnTick = 0.00125f;
     private const float SkirmishMoraleGainMultiplierLastFlag = 2f;
     private const int LossMultiplier = 2;
@@ -301,16 +300,16 @@ internal class CrpgBattleServer : MissionMultiplayerGameModeBase
         }
 
         float moraleGainOnTick = _gametype == MultiplayerGameType.Skirmish ? SkirmishMoraleGainOnTick : BattleMoraleGainOnTick;
-        float moraleGainMultiplierLastFlag = _gametype == MultiplayerGameType.Skirmish ? SkirmishMoraleGainMultiplierLastFlag : BattleMoraleGainMultiplierLastFlag;
 
         float moraleMultiplier = moraleGainOnTick * Math.Abs(teamFlagsDelta);
         float moraleGain = teamFlagsDelta <= 0
             ? MBMath.ClampFloat(-1 - _morale, -2f, -1f) * moraleMultiplier
             : MBMath.ClampFloat(1 - _morale, 1f, 2f) * moraleMultiplier;
-        // For the last flag on multi-flag maps, the morale is moving faster.
-        if (_flagSystem.HasFlagCountChanged() && _flagSystem.GetAllFlags().Length > 1)
+        // In skirmish, morale moves faster once flags are reduced to one.
+        // In battle, there is always a single flag so no multiplier applies.
+        if (_gametype == MultiplayerGameType.Skirmish && _flagSystem.HasFlagCountChanged())
         {
-            moraleGain *= moraleGainMultiplierLastFlag;
+            moraleGain *= SkirmishMoraleGainMultiplierLastFlag;
         }
 
         return moraleGain;


### PR DESCRIPTION
Battle mode always has a single flag (spawned from deactivated flags), so the 2x morale multiplier designed for the last-flag phase never made sense. The multiplier now only applies in skirmish when multiple flags are reduced to one.