### PR TITLE
mod: fix battle HUD power bar for spectators and initial count tracking

### DIFF
--- a/src/Module.Client/GUI/HudExtension/CrpgCommanderInfoVm.cs
+++ b/src/Module.Client/GUI/HudExtension/CrpgCommanderInfoVm.cs
@@ -15,7 +15,6 @@ public class CrpgCommanderInfoVm : ViewModel
 {
     private readonly MissionMultiplayerGameModeBaseClient _gameMode;
     private readonly CrpgSiegeClient? _siegeClient;
-    private readonly MissionScoreboardComponent _missionScoreboardComponent;
     private readonly ICommanderInfo? _commanderInfo;
     private int _attackerTeamInitialMemberCount;
     private int _defenderTeamInitialMemberCount;
@@ -48,7 +47,6 @@ public class CrpgCommanderInfoVm : ViewModel
         NeutralControlPoints = new MBBindingList<CapturePointVM>();
         EnemyControlPoints = new MBBindingList<CapturePointVM>();
         _gameMode = Mission.Current.GetMissionBehavior<MissionMultiplayerGameModeBaseClient>();
-        _missionScoreboardComponent = Mission.Current.GetMissionBehavior<MissionScoreboardComponent>();
         _commanderInfo = Mission.Current.GetMissionBehavior<ICommanderInfo>();
         ShowTacticalInfo = true;
         UpdateWarmupDependentFlags(_gameMode.IsInWarmup);
@@ -431,20 +429,19 @@ public class CrpgCommanderInfoVm : ViewModel
 
         int activeAttackersCount = Mission.Current.AttackerTeam.ActiveAgents.Count;
         int activeDefendersCount = Mission.Current.DefenderTeam.ActiveAgents.Count;
+        _attackerTeamInitialMemberCount = MathF.Max(_attackerTeamInitialMemberCount, activeAttackersCount);
+        _defenderTeamInitialMemberCount = MathF.Max(_defenderTeamInitialMemberCount, activeDefendersCount);
         AllyMemberCount = _allyTeam.Side == BattleSideEnum.Attacker ? activeAttackersCount : activeDefendersCount;
         EnemyMemberCount = _allyTeam.Side == BattleSideEnum.Attacker ? activeDefendersCount : activeAttackersCount;
-        int initialAttackerPower = _allyTeam.Side == BattleSideEnum.Attacker ? _attackerTeamInitialMemberCount : _defenderTeamInitialMemberCount;
-        Team? allyTeam = _allyTeam;
-        int initialDefenderPower = (allyTeam != null
-            ? allyTeam.Side == BattleSideEnum.Attacker ? 1 : 0
-            : 0) != 0 ? _defenderTeamInitialMemberCount : _attackerTeamInitialMemberCount;
-        if (initialDefenderPower == 0 && initialAttackerPower == 0)
+        int initialAllyPower = _allyTeam.Side == BattleSideEnum.Attacker ? _attackerTeamInitialMemberCount : _defenderTeamInitialMemberCount;
+        int initialEnemyPower = _allyTeam.Side == BattleSideEnum.Attacker ? _defenderTeamInitialMemberCount : _attackerTeamInitialMemberCount;
+        if (initialAllyPower == 0 && initialEnemyPower == 0)
         {
             PowerLevelComparer.Update(1.0, 1.0, 1.0, 1.0);
         }
         else
         {
-            PowerLevelComparer.Update(EnemyMemberCount, AllyMemberCount, initialDefenderPower, initialAttackerPower);
+            PowerLevelComparer.Update(EnemyMemberCount, AllyMemberCount, initialEnemyPower, initialAllyPower);
         }
     }
 
@@ -524,13 +521,6 @@ public class CrpgCommanderInfoVm : ViewModel
     {
         ShowTacticalInfo = true;
         OnTeamChanged();
-        if (!UsePowerComparer)
-        {
-            return;
-        }
-
-        _attackerTeamInitialMemberCount = _missionScoreboardComponent.Sides[(int)BattleSideEnum.Attacker].Players.Count<MissionPeer>();
-        _defenderTeamInitialMemberCount = _missionScoreboardComponent.Sides[(int)BattleSideEnum.Defender].Players.Count<MissionPeer>();
     }
 
     private void RegisterMoraleEvents()
@@ -562,6 +552,8 @@ public class CrpgCommanderInfoVm : ViewModel
             return;
         }
 
+        _attackerTeamInitialMemberCount = 0;
+        _defenderTeamInitialMemberCount = 0;
         PowerLevelComparer.Update(1.0, 1.0, 1.0, 1.0);
     }
 

--- a/src/Module.Client/GUI/HudExtension/CrpgHudExtensionVm.cs
+++ b/src/Module.Client/GUI/HudExtension/CrpgHudExtensionVm.cs
@@ -91,8 +91,8 @@ internal class CrpgHudExtensionVm : ViewModel
 
     private void HandleBannerChange(string attackerBanner, string defenderBanner, string attackerName, string defenderName)
     {
-        AllyBanner = new(GameNetwork.MyPeer.GetComponent<MissionPeer>()?.Team?.Side == BattleSideEnum.Attacker ? new Banner(attackerBanner) : new Banner(defenderBanner), true);
-        EnemyBanner = new(GameNetwork.MyPeer.GetComponent<MissionPeer>()?.Team?.Side == BattleSideEnum.Attacker ? new Banner(defenderBanner) : new Banner(attackerBanner), true);
+        AllyBanner = new(_isAttackerTeamAlly ? new Banner(attackerBanner) : new Banner(defenderBanner), true);
+        EnemyBanner = new(_isAttackerTeamAlly ? new Banner(defenderBanner) : new Banner(attackerBanner), true);
     }
 
     [DataSourceProperty]


### PR DESCRIPTION
## Problem

The battle HUD power bar had several issues:

1. **Bar stuck at 50/50 for spectators** - Initial member counts were only set in `OnMyAgentSpawnedFromVisual()`, which never fires for spectators. Both counts stayed at 0, forcing `PowerLevelComparer.Update(1.0, 1.0, 1.0, 1.0)` every tick.

2. **Bar stayed at 100% until well below initial player count** - The scoreboard-based count in `OnMyAgentSpawnedFromVisual` could capture a count lower than the actual number of active agents (timing issue). Since `FillBarWidget` clamps at `MaxAmountAsFloat=1.0`, any ratio > 1.0 showed as full.

3. **Banner colors mismatched for spectators** - `HandleBannerChange` checked `Side == BattleSideEnum.Attacker` (false for spectators with Side.None, treating them as defenders), while `OnTeamChanged` used `Side == Attacker || Side == None` (treating them as attackers). This caused banners to show defender colors but morale/power to use attacker colors.

## Fix

- Track initial member counts via `MathF.Max(initial, activeCount)` in `Tick()` instead of a one-shot scoreboard read. The peak active agent count naturally represents the round's starting strength.
- Reset initial counts to 0 in `OnMissionReset` so they recalculate each round.
- Use `_isAttackerTeamAlly` in `HandleBannerChange` for consistent spectator handling.
- Remove unused `_missionScoreboardComponent` field.
