### PR TITLE
mod: fix commander order crash on Linux servers

### DIFF
--- a/src/Module.Server/Common/ChatCommands/ChatCommandsComponent.cs
+++ b/src/Module.Server/Common/ChatCommands/ChatCommandsComponent.cs
@@ -154,8 +154,13 @@ internal class ChatCommandsComponent : GameHandler
         }
 
         GameNetwork.NetworkMessageHandlerRegisterer handlerRegisterer = new(mode);
-        handlerRegisterer.Register<PlayerMessageAll>(HandleClientEventPlayerMessage);
-        handlerRegisterer.Register<PlayerMessageTeam>(HandleClientEventPlayerMessage);
+        // Use RegisterBaseHandler instead of Register to avoid DynamicInvoke. Register<T> stores
+        // handlers as objects and invokes them via Delegate.DynamicInvoke -> RuntimeMethodHandle.InvokeMethod.
+        // That path crashes with ExecutionEngineException when the handler makes native P/Invoke calls
+        // (e.g. MakeVoice) inside the reverse P/Invoke context of HandleNetworkPacketAsServer.
+        // Bannerlord's own order handlers (ApplyOrder etc.) use RegisterBaseHandler for the same reason.
+        handlerRegisterer.RegisterBaseHandler<PlayerMessageAll>(HandleClientEventPlayerMessage);
+        handlerRegisterer.RegisterBaseHandler<PlayerMessageTeam>(HandleClientEventPlayerMessage);
     }
 
     private bool HandleClientEventPlayerMessage(NetworkCommunicator peer, GameNetworkMessage message)

--- a/src/Module.Server/Common/ChatCommands/Commander/OrderCommand.cs
+++ b/src/Module.Server/Common/ChatCommands/Commander/OrderCommand.cs
@@ -19,7 +19,9 @@ internal class OrderCommand : CommanderCommand
     {
         string message = (string)arguments[0];
         MissionPeer? missionPeer = fromPeer.GetComponent<MissionPeer>();
-        fromPeer.ControlledAgent.MakeVoice(SkinVoiceManager.VoiceType.Yell, SkinVoiceManager.CombatVoiceNetworkPredictionType.NoPrediction);
+        // MakeVoice disabled: this native P/Invoke into the engine's sound system caused ExecutionEngineException
+        // crashes on Linux servers when called during network packet processing.
+        // fromPeer.ControlledAgent.MakeVoice(SkinVoiceManager.VoiceType.Yell, SkinVoiceManager.CombatVoiceNetworkPredictionType.NoPrediction);
         foreach (NetworkCommunicator targetPeer in GameNetwork.NetworkPeers)
         {
             if (targetPeer.GetComponent<MissionPeer>()?.Team.Side == missionPeer.Team.Side)


### PR DESCRIPTION
## Problem

The Linux game servers crash with `ExecutionEngineException: attempted to call a UnmanagedCallersOnly method from managed code` whenever a player uses the `!o` (commander order) chat command. This has been happening repeatedly (4 crashes on Mar 19 alone on crpg03).

## Root Cause

Crash dump analysis (core dumps from crpg03, PIDs 660036 and 661199) confirmed:

- Both dumps had the `!o` command being processed at crash time
- The handler **executed successfully** (OrderCommand objects, parsed tokens, CrpgNotification objects all present on heap)
- The crash occurs in `DynamicInvoke` / `RuntimeMethodHandle.InvokeMethod` when processing the return

The crash is caused by two interacting factors:

**1. `MakeVoice` (native P/Invoke) inside a DynamicInvoke callback from a reverse P/Invoke:**

```
Native engine (packet processing)
  -> [reverse P/Invoke] managed code
    -> DynamicInvoke (reflection)
      -> OrderCommand.ExecuteAnnouncement
        -> Agent.MakeVoice()  [P/Invoke back into native engine]
      <- handler returns
    <- DynamicInvoke processes return  <-- CRASH
```

`MakeVoice` calls into the engine's sound system, which corrupts CLR runtime state. When `InvokeMethod` tries to process the return, it hits the corrupted state and throws a fatal `ExecutionEngineException`.

**2. `Register<T>()` uses DynamicInvoke, which is sensitive to this corruption:**

Bannerlord has two handler registration paths:

| Path | Registration | Invocation |
|------|-------------|------------|
| `_fromClientBaseMessageHandlers` | `RegisterBaseHandler<T>()` | Direct delegate call |
| `_fromClientMessageHandlers` | `Register<T>()` | `Delegate.DynamicInvoke()` -> `RuntimeMethodHandle.InvokeMethod` |

Bannerlord's own order system (`ApplyOrder` etc.) uses `RegisterBaseHandler` for handlers that call `MakeVoice` via `OrderController`. cRPG's chat handler used `Register<T>()`, putting it on the DynamicInvoke path.

**Evidence that `MakeVoice` is the trigger:**

| Factor | MakeVoice | BeginModuleEventAsServer |
|--------|-----------|--------------------------|
| Unique to `!o`? | **Yes** | No -- ChatBox does the same |
| Regular chat crashes? | N/A | No |
| Bannerlord's own order handlers | Use `RegisterBaseHandler` | Used by ChatBox via `Register` without issues |

## Fix

1. **`ChatCommandsComponent`**: Switch from `Register<T>()` to `RegisterBaseHandler<T>()` -- avoids DynamicInvoke entirely (matches what Bannerlord does for its own order handlers)
2. **`OrderCommand`**: Disable `MakeVoice` call -- eliminates the native P/Invoke that corrupts CLR state

Both fixes together provide defense in depth. The `RegisterBaseHandler` change also protects against future native calls in chat command handlers.

**Impact**: Commander order messages still work. The yell voice effect is lost.
