### PR TITLE
mod: use battle_losing/winning sounds for commander death

### DIFF
--- a/src/Module.Server/Common/Commander/CrpgCommanderBehaviorClient.cs
+++ b/src/Module.Server/Common/Commander/CrpgCommanderBehaviorClient.cs
@@ -191,7 +191,7 @@ internal class CrpgCommanderBehaviorClient : MissionNetwork
         {
             Information = textObject.ToString(),
             Color = commanderSide == mySide ? new Color(0.90f, 0.25f, 0.25f) : new Color(0.1f, 1f, 0f),
-            SoundEventPath = commanderSide == mySide ? "event:/ui/mission/multiplayer/pointlost" : "event:/ui/mission/multiplayer/pointcapture",
+            SoundEventPath = commanderSide == mySide ? "event:/alerts/report/battle_losing" : "event:/alerts/report/battle_winning",
         });
     }
 


### PR DESCRIPTION
Replace generic flag capture/lost jingles (pointlost/pointcapture) which were too much with more fitting battle_losing/battle_winning alert sounds when a commander dies.