### PR TITLE
fix: resolve agent label race condition when spectating after death

### DIFF
--- a/src/Module.Client/GUI/CrpgAgentLabelView.cs
+++ b/src/Module.Client/GUI/CrpgAgentLabelView.cs
@@ -26,6 +26,7 @@ internal class CrpgAgentLabelView : MissionView
     private bool _isResumingView;
     private bool _alwaysShowBanners;
     private bool _indicatorsActive;
+    private bool _isSpectating;
 
     private bool IndicatorsActive
     {
@@ -58,6 +59,12 @@ internal class CrpgAgentLabelView : MissionView
     public override void OnMissionTick(float dt)
     {
         IndicatorsActive = _alwaysShowBanners || Input.IsGameKeyDown(5);
+        bool spectating = IsSpectating();
+        if (_isSpectating != spectating)
+        {
+            _isSpectating = spectating;
+            UpdateAllAgentMeshVisibilities();
+        }
     }
 
     public override void OnRemoveBehavior()


### PR DESCRIPTION
## Problem

When the player dies, enemy labels (team banner circles above heads) fail to appear most of the time. Occasionally only a few enemy labels show up.

## Root Cause

When an agent is removed, Bannerlord processes events in this order:

1. `agent.State = Killed`
2. `OnAgentRemoved` callbacks
3. `Mission.MainAgent = null` -> triggers `OnMainAgentChanged` -> `UpdateAllAgentMeshVisibilities()`
4. *(next tick)* `MissionPeer.ControlledAgent = null`

At step 3, `IsSpectating()` checks `missionPeer.ControlledAgent == null`, which is still **false** (cleared on next tick). So it returns `false`, and `ShouldShowLabel` falls through to `IsAlly()` which hides enemy labels.

The "sometimes a few labels show" behavior occurs because `OnSpectateAgentFocusIn/Out` updates individual agents after the next tick, when `ControlledAgent` has been properly cleared.

## Fix

Track spectating state in `OnMissionTick` and trigger a full visibility refresh when the state transitions, similar to how `_indicatorsActive` already works. This catches the state change once `ControlledAgent` is cleared on the next tick.
