### PR TITLE
mod: revert environment capsule to step 3

### DIFF
--- a/src/Module.Server/ModuleData/native_parameters.xml
+++ b/src/Module.Server/ModuleData/native_parameters.xml
@@ -16,6 +16,6 @@
     <native_parameter id="ladder_climb_up_speed_multiplier"  value="0.88" /> <!-- Native = 0.68-->
     <native_parameter id="humanoid_physics_capsule_radius_multiplier_for_friend" value="1.35" /> <!--Native = 0.95-->
     <native_parameter	id="humanoid_physics_capsule_radius_multiplier_for_enemy"	value="2.005" /> <!--Native = 1.5-->
-    <native_parameter id="smaller_humanoid_physics_capsule_radius_multiplier_for_static_bodies" value="0.89" /> <!--Environment (trees/walls, any entities) Native = 0.67-->
+    <native_parameter id="smaller_humanoid_physics_capsule_radius_multiplier_for_static_bodies" value="0.845" /> <!--Environment (trees/walls, any entities) Native = 0.67-->
   </native_parameters>
 </base>


### PR DESCRIPTION
Revert environment capsule to step 3 due to collision issues

The capsule since step 4 is believed to be causing collision issues in that players on horseback are falling through the floor upon being dismounted and/or teleporting to random spaces in the map (spawn, into the sky above the dead horse and plummeting to their death)

Revert the environment capsule back to step 3 before issues were noted as a method of testing whether this is likely the culprit or not.