### PR TITLE
mod: reduce xbow movespeed while reloading

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -411,6 +411,9 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                     props.WeaponRotationalAccuracyPenaltyInRadians /= ImpactOfStrReqOnCrossbows(agent, 0.3f, primaryItem);
                     props.ThrustOrRangedReadySpeedMultiplier *= 0.4f * (float)Math.Pow(2, weaponSkill / 191f) * ImpactOfStrReqOnCrossbows(agent, 0.3f, primaryItem); // Multiplying make windup time slower a 0 wpf, faster at 80 wpf
                     props.ReloadSpeed *= ImpactOfStrReqOnCrossbows(agent, 0.15f, primaryItem);
+
+                    // slow on reload (kicks in a bit late tho)
+                    props.BipedalRangedReloadSpeedMultiplier = 0.1f;
                 }
 
                 // Bows


### PR DESCRIPTION
Players could previously kite indefinitely while reloading a crossbow, creating an unintended gameplay advantage. This change reduces movement speed during the reload phase to limit mobility and restore intended balance.