### PR TITLE
mod: Further increase to nudge cooldown

### DIFF
--- a/src/Module.Server/ModuleData/combat_parameters.xml
+++ b/src/Module.Server/ModuleData/combat_parameters.xml
@@ -20,11 +20,11 @@
     <def name="thrust_ladder_rot_limit_right" val="57.3" /> <!-- native is 57.3 -->
     <def name="overswing_ladder_rot_limit_left"  val="67.3" />
     <def name="overswing_ladder_rot_limit_right" val="57.3" />
-    <def name="weapon_1h_bash_cooldown" val="1.75" />
-    <def name="weapon_2h_bash_cooldown" val="1.75" />
-    <def name="weapon_spear_bash_cooldown" val="1.75" />
-    <def name="shield_bash_cooldown" val="2.15" />
-    <def name="hand_shield_bash_cooldown" val="2.15" />
+    <def name="weapon_1h_bash_cooldown" val="2.00" />
+    <def name="weapon_2h_bash_cooldown" val="2.00" />
+    <def name="weapon_spear_bash_cooldown" val="2.00" />
+    <def name="shield_bash_cooldown" val="2.40" />
+    <def name="hand_shield_bash_cooldown" val="2.40" />
 
   </definitions>
 


### PR DESCRIPTION
Boost nudge cooldown by 0.25 seconds to address unintended use-cases

Nudges were originally boosted by 0.25 seconds to attempt to address problematic use-cases where one can infinitely chain nudges after an attack (attack -> nudge -> attack -> nudge) effectively mitigating a persons ability to retaliate, the initial cooldown has been, after testing, unsuccessful in achieving this goal, so this is a further increase to continue the attempts to resolve that issue.

## OLD
```
    <def name="weapon_1h_bash_cooldown" val="1.75" />
    <def name="weapon_2h_bash_cooldown" val="1.75" />
    <def name="weapon_spear_bash_cooldown" val="1.75" />
    <def name="shield_bash_cooldown" val="2.15" />
    <def name="hand_shield_bash_cooldown" val="2.15" />
```

## NEW
```
    <def name="weapon_1h_bash_cooldown" val="2.00" />
    <def name="weapon_2h_bash_cooldown" val="2.00" />
    <def name="weapon_spear_bash_cooldown" val="2.00" />
    <def name="shield_bash_cooldown" val="2.40" />
    <def name="hand_shield_bash_cooldown" val="2.40" />
```