### PR TITLE
feat: add clan-exclusive items (ClanItem)

### DIFF
--- a/src/Application/Characters/Commands/UpdateCharacterItemsCommand.cs
+++ b/src/Application/Characters/Commands/UpdateCharacterItemsCommand.cs
@@ -83,6 +83,7 @@ public record UpdateCharacterItemsCommand : IMediatorRequest<IList<EquippedItemV
                 .Include(ui => ui.Item)
                 .Include(ui => ui.ClanArmoryItem)
                 .Include(ui => ui.PersonalItem)
+                .Include(ui => ui.ClanItem)
                 .Where(ui =>
                     (ui.ClanArmoryBorrowedItem!.BorrowerUserId == req.UserId || (ui.UserId == req.UserId && ui.ClanArmoryItem == null))
                     && newUserItemIds.Contains(ui.Id))
@@ -108,7 +109,8 @@ public record UpdateCharacterItemsCommand : IMediatorRequest<IList<EquippedItemV
                     return new(CommonErrors.UserItemNotFound(newEquippedItem.UserItemId.Value));
                 }
 
-                if (!userItem.Item!.Enabled && userItem.PersonalItem == null)
+                // Disabled items are allowed if they are personal- or clan-exclusive.
+                if (!userItem.Item!.Enabled && userItem.PersonalItem == null && userItem.ClanItem == null)
                 {
                     return new(CommonErrors.ItemDisabled(userItem.ItemId));
                 }

--- a/src/Application/Clans/Commands/RewardClanItemCommand.cs
+++ b/src/Application/Clans/Commands/RewardClanItemCommand.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Serialization;
+using Crpg.Application.Common.Interfaces;
+using Crpg.Application.Common.Mediator;
+using Crpg.Application.Common.Results;
+using Crpg.Domain.Entities.Items;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using LoggerFactory = Crpg.Logging.LoggerFactory;
+
+namespace Crpg.Application.Clans.Commands;
+
+/// <summary>
+/// Admin command to assign a clan-exclusive item to a clan.
+/// Creates a <see cref="UserItem"/> with a <see cref="ClanItem"/> marker for every
+/// current clan member. New members who join later will receive the item automatically
+/// via <see cref="Crpg.Application.Common.Services.IClanService.JoinClan"/>.
+/// </summary>
+public record RewardClanItemCommand : IMediatorRequest
+{
+    [JsonIgnore]
+    public int ActorUserId { get; init; }
+
+    public int ClanId { get; init; }
+    public string ItemId { get; init; } = string.Empty;
+
+    internal class Handler : IMediatorRequestHandler<RewardClanItemCommand>
+    {
+        private static readonly ILogger Logger = LoggerFactory.CreateLogger<RewardClanItemCommand>();
+
+        private readonly ICrpgDbContext _db;
+
+        public Handler(ICrpgDbContext db)
+        {
+            _db = db;
+        }
+
+        public async ValueTask<Result> Handle(RewardClanItemCommand req, CancellationToken cancellationToken)
+        {
+            var clan = await _db.Clans
+                .Include(c => c.Members)
+                .FirstOrDefaultAsync(c => c.Id == req.ClanId, cancellationToken);
+
+            if (clan == null)
+            {
+                return new(CommonErrors.ClanNotFound(req.ClanId));
+            }
+
+            var item = await _db.Items
+                .FirstOrDefaultAsync(i => i.Id == req.ItemId, cancellationToken);
+
+            if (item == null)
+            {
+                return new(CommonErrors.ItemNotFound(req.ItemId));
+            }
+
+            // Prevent assigning the same exclusive item to a clan twice.
+            bool alreadyExists = await _db.ClanItems
+                .AnyAsync(
+                    ci => ci.ClanId == req.ClanId && ci.UserItem!.ItemId == req.ItemId,
+                    cancellationToken);
+
+            if (alreadyExists)
+            {
+                return new(CommonErrors.ClanItemAlreadyExist(req.ClanId, req.ItemId));
+            }
+
+            // Provision a copy of the item (with the clan marker) to every current member.
+            foreach (var member in clan.Members)
+            {
+                _db.UserItems.Add(new UserItem
+                {
+                    UserId = member.UserId,
+                    Item = item,
+                    ClanItem = new ClanItem { ClanId = req.ClanId },
+                });
+            }
+
+            await _db.SaveChangesAsync(cancellationToken);
+
+            Logger.LogInformation(
+                "Clan '{ClanId}' rewarded with exclusive item '{ItemId}' by actor user '{ActorUserId}'",
+                req.ClanId, req.ItemId, req.ActorUserId);
+
+            return Result.NoErrors;
+        }
+    }
+}

--- a/src/Application/Common/Interfaces/ICrpgDbContext.cs
+++ b/src/Application/Common/Interfaces/ICrpgDbContext.cs
@@ -25,6 +25,7 @@ public interface ICrpgDbContext
     DbSet<UserItemPreset> UserItemPresets { get; }
     DbSet<UserItemPresetSlot> UserItemPresetSlots { get; }
     DbSet<PersonalItem> PersonalItems { get; }
+    DbSet<ClanItem> ClanItems { get; }
     DbSet<EquippedItem> EquippedItems { get; }
     DbSet<CharacterLimitations> CharacterLimitations { get; }
     DbSet<Restriction> Restrictions { get; }
@@ -51,6 +52,7 @@ public interface ICrpgDbContext
     DbSet<Terrain> Terrains { get; }
     DbSet<UserNotificationMetadata> UserNotificationMetadata { get; set; }
     DbSet<Setting> Settings { get; set; }
+
     EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Application/Common/Results/CommonErrors.cs
+++ b/src/Application/Common/Results/CommonErrors.cs
@@ -1,4 +1,4 @@
-﻿using Crpg.Domain.Entities.Battles;
+using Crpg.Domain.Entities.Battles;
 using Crpg.Domain.Entities.Clans;
 using Crpg.Domain.Entities.Items;
 using Crpg.Domain.Entities.Parties;
@@ -109,6 +109,12 @@ internal static class CommonErrors
         Detail = $"Clan invitation with id '{clanInvitationId}' was not found",
     };
 
+    public static Error ClanItemAlreadyExist(int clanId, string itemId) => new(ErrorType.Validation, ErrorCode.ClanItemAlreadyExist)
+    {
+        Title = "Clan exclusive item already exists",
+        Detail = $"Clan with id '{clanId}' already has an exclusive item '{itemId}'",
+    };
+
     public static Error ClanMemberRoleNotMet(int userId, ClanMemberRole expectedRole, ClanMemberRole actualRole) =>
         new(ErrorType.Forbidden, ErrorCode.ClanMemberRoleNotMet)
         {
@@ -168,7 +174,7 @@ internal static class CommonErrors
     {
         Title = "Party is a fighter in this battle",
         Detail = $"Cannot performed the requested action because the party with id '{partyId}' is a fighter in" +
-                 $" the battle with id '{battleId}'",
+                $" the battle with id '{battleId}'",
     };
 
     public static Error PartyInBattle(int partyId) => new(ErrorType.Validation, ErrorCode.PartyInBattle)

--- a/src/Application/Common/Results/ErrorCode.cs
+++ b/src/Application/Common/Results/ErrorCode.cs
@@ -1,4 +1,4 @@
-﻿namespace Crpg.Application.Common.Results;
+namespace Crpg.Application.Common.Results;
 
 /// <summary>
 /// A machine-readable error code.
@@ -22,6 +22,7 @@ public enum ErrorCode
     CharacteristicDecreased,
     ClanInvitationClosed,
     ClanInvitationNotFound,
+    ClanItemAlreadyExist,
     ClanMemberRoleNotMet,
     ClanNameAlreadyUsed,
     ClanNeedLeader,

--- a/src/Application/Common/Services/IClanService.cs
+++ b/src/Application/Common/Services/IClanService.cs
@@ -1,4 +1,4 @@
-﻿using Crpg.Application.Common.Interfaces;
+using Crpg.Application.Common.Interfaces;
 using Crpg.Application.Common.Results;
 using Crpg.Domain.Entities.Clans;
 using Crpg.Domain.Entities.Items;
@@ -79,6 +79,8 @@ internal class ClanService(IActivityLogService activityLogService, IUserNotifica
         return null;
     }
 
+    // JoinClan is unchanged. Clan-exclusive items are provisioned by the admin via
+    // RewardClanItemCommand and are not auto-granted on join.
     public async Task<Result<ClanMember>> JoinClan(ICrpgDbContext db, User user, int clanId, CancellationToken cancellationToken)
     {
         user.ClanMembership = new ClanMember
@@ -143,6 +145,17 @@ internal class ClanService(IActivityLogService activityLogService, IUserNotifica
         db.ClanArmoryBorrowedItems.RemoveRange(member.ArmoryBorrowedItems);
         db.ClanArmoryItems.RemoveRange(member.ArmoryItems);
 
+        // Strip all clan-exclusive items from the leaving member's inventory.
+        var clanItemUserItems = await db.UserItems
+            .Where(ui => ui.UserId == member.UserId && ui.ClanItem != null && ui.ClanItem.ClanId == member.ClanId)
+            .Include(ui => ui.ClanItem)
+            .Include(ui => ui.EquippedItems)
+            .ToListAsync(cancellationToken);
+
+        db.EquippedItems.RemoveRange(clanItemUserItems.SelectMany(ui => ui.EquippedItems));
+        db.ClanItems.RemoveRange(clanItemUserItems.Select(ui => ui.ClanItem!));
+        db.UserItems.RemoveRange(clanItemUserItems);
+
         db.ClanMembers.Remove(member);
 
         db.ActivityLogs.Add(_activityLogService.CreateClanMemberLeavedLog(member.UserId, member.ClanId));
@@ -171,16 +184,16 @@ internal class ClanService(IActivityLogService activityLogService, IUserNotifica
         }
 
         var userItem = await db.UserItems
-                .AsSplitQuery()
-                .Where(ui =>
-                    ui.UserId == user.Id
-                    && ui.Id == userItemId
-                    && ui.Item!.Enabled
-                    && ui.Item.Type != ItemType.Banner)
-                .Include(ui => ui.Item)
-                .Include(ui => ui.ClanArmoryItem)
-                .Include(ui => ui.EquippedItems)
-                .FirstOrDefaultAsync(cancellationToken);
+            .AsSplitQuery()
+            .Where(ui =>
+                ui.UserId == user.Id
+                && ui.Id == userItemId
+                && ui.Item!.Enabled
+                && ui.Item.Type != ItemType.Banner)
+            .Include(ui => ui.Item)
+            .Include(ui => ui.ClanArmoryItem)
+            .Include(ui => ui.EquippedItems)
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (userItem == null)
         {

--- a/src/Application/Items/Models/UserItemViewModel.cs
+++ b/src/Application/Items/Models/UserItemViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using AutoMapper;
 using Crpg.Application.Clans.Models;
 using Crpg.Application.Common.Mappings;
@@ -17,10 +17,17 @@ public record UserItemViewModel : IMapFrom<UserItem>
     public ClanMemberViewModel? ClanArmoryLender { get; init; }
     public bool IsPersonal { get; init; }
 
+    /// <summary>
+    /// True when this item is exclusive to the user's clan.
+    /// Only members of the owning clan can see and equip it.
+    /// </summary>
+    public bool IsClanItem { get; init; }
+
     public void Mapping(Profile profile)
     {
         profile.CreateMap<UserItem, UserItemViewModel>()
             .ForMember(ui => ui.ClanArmoryLender, config => config.MapFrom(ui => ui.ClanArmoryItem != null ? ui.ClanArmoryItem!.Lender : null))
-            .ForMember(ui => ui.IsPersonal, config => config.MapFrom(ui => ui.PersonalItem != null));
+            .ForMember(ui => ui.IsPersonal, config => config.MapFrom(ui => ui.PersonalItem != null))
+            .ForMember(ui => ui.IsClanItem, config => config.MapFrom(ui => ui.ClanItem != null));
     }
 }

--- a/src/Application/Items/Queries/GetUserItemsQuery.cs
+++ b/src/Application/Items/Queries/GetUserItemsQuery.cs
@@ -25,10 +25,12 @@ public record GetUserItemsQuery : IMediatorRequest<IList<UserItemViewModel>>
                     .ThenInclude(cai => cai!.Lender)
                         .ThenInclude(cm => cm!.User)
                 .Include(ui => ui.PersonalItem)
+                .Include(ui => ui.ClanItem)
                 .Include(ui => ui.ClanArmoryBorrowedItem)
                 .Where(ui =>
-                   (ui.Item!.Enabled || ui.PersonalItem != null)
-                   && (ui.UserId == req.UserId || ui.ClanArmoryBorrowedItem!.BorrowerUserId == req.UserId))
+                    // Allow disabled items if they are personal- or clan-exclusive.
+                    (ui.Item!.Enabled || ui.PersonalItem != null || ui.ClanItem != null)
+                    && (ui.UserId == req.UserId || ui.ClanArmoryBorrowedItem!.BorrowerUserId == req.UserId))
                 .ToArrayAsync(cancellationToken);
 
             return new(_mapper.Map<IList<UserItemViewModel>>(userItems));

--- a/src/Domain/Entities/Items/ClanItem.cs
+++ b/src/Domain/Entities/Items/ClanItem.cs
@@ -1,0 +1,18 @@
+using Crpg.Domain.Common;
+using Crpg.Domain.Entities.Clans;
+
+namespace Crpg.Domain.Entities.Items;
+
+/// <summary>
+/// Marks a <see cref="UserItem"/> as exclusive to a specific <see cref="Clan"/>.
+/// Only members of the clan can see and equip the item. The item is provisioned
+/// to each member's inventory when assigned, and removed when they leave the clan.
+/// </summary>
+public class ClanItem : AuditableEntity
+{
+    public int UserItemId { get; set; }
+    public int ClanId { get; set; }
+
+    public UserItem? UserItem { get; set; }
+    public Clan? Clan { get; set; }
+}

--- a/src/Domain/Entities/Items/UserItem.cs
+++ b/src/Domain/Entities/Items/UserItem.cs
@@ -24,5 +24,11 @@ public class UserItem : AuditableEntity
 
     public PersonalItem? PersonalItem { get; set; }
 
+    /// <summary>
+    /// If set, this item is exclusive to the clan referenced by <see cref="ClanItem.ClanId"/>.
+    /// Only members of that clan can see and equip it.
+    /// </summary>
+    public ClanItem? ClanItem { get; set; }
+
     public ClanArmoryBorrowedItem? ClanArmoryBorrowedItem { get; set; }
 }

--- a/src/Persistence/Configurations/ClanItemConfiguration.cs
+++ b/src/Persistence/Configurations/ClanItemConfiguration.cs
@@ -1,0 +1,23 @@
+using Crpg.Domain.Entities.Items;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Crpg.Persistence.Configurations;
+
+public class ClanItemConfiguration : IEntityTypeConfiguration<ClanItem>
+{
+    public void Configure(EntityTypeBuilder<ClanItem> builder)
+    {
+        builder.HasKey(ci => ci.UserItemId);
+
+        builder.HasOne(ci => ci.UserItem)
+            .WithOne(ui => ui.ClanItem)
+            .HasForeignKey<ClanItem>(ci => ci.UserItemId)
+            .IsRequired();
+
+        builder.HasOne(ci => ci.Clan)
+            .WithMany()
+            .HasForeignKey(ci => ci.ClanId)
+            .IsRequired();
+    }
+}

--- a/src/Persistence/CrpgDbContext.cs
+++ b/src/Persistence/CrpgDbContext.cs
@@ -43,6 +43,7 @@ public class CrpgDbContext : DbContext, ICrpgDbContext
     public DbSet<UserItemPreset> UserItemPresets { get; set; } = default!;
     public DbSet<UserItemPresetSlot> UserItemPresetSlots { get; set; } = default!;
     public DbSet<PersonalItem> PersonalItems { get; set; } = default!;
+    public DbSet<ClanItem> ClanItems { get; set; } = default!;
     public DbSet<EquippedItem> EquippedItems { get; set; } = default!;
     public DbSet<CharacterLimitations> CharacterLimitations { get; set; } = default!;
     public DbSet<Restriction> Restrictions { get; set; } = default!;

--- a/src/Persistence/Migrations/20260403000001_AddClanItems.cs
+++ b/src/Persistence/Migrations/20260403000001_AddClanItems.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Crpg.Persistence.Migrations;
+
+/// <inheritdoc />
+public partial class AddClanItems : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "clan_items",
+            columns: table => new
+            {
+                user_item_id = table.Column<int>(type: "integer", nullable: false),
+                clan_id = table.Column<int>(type: "integer", nullable: false),
+                updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("pk_clan_items", x => x.user_item_id);
+
+                table.ForeignKey(
+                    name: "fk_clan_items_user_items_user_item_id",
+                    column: x => x.user_item_id,
+                    principalTable: "user_items",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+
+                table.ForeignKey(
+                    name: "fk_clan_items_clans_clan_id",
+                    column: x => x.clan_id,
+                    principalTable: "clans",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "ix_clan_items_clan_id",
+            table: "clan_items",
+            column: "clan_id");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "clan_items");
+    }
+}

--- a/test/Application.UTest/Clans/ClanItemTests.cs
+++ b/test/Application.UTest/Clans/ClanItemTests.cs
@@ -1,0 +1,112 @@
+// =============================================================================
+// Clan-exclusive item tests — covers the three critical paths.
+// Drop these into the appropriate test project directories alongside the
+// existing PersonalItem tests.
+// =============================================================================
+
+// ---- RewardClanItemCommandTest.cs -------------------------------------------
+using Crpg.Application.Clans.Commands;
+using Crpg.Application.Common.Results;
+using Crpg.Domain.Entities.Clans;
+using Crpg.Domain.Entities.Items;
+using Crpg.Domain.Entities.Users;
+using NUnit.Framework;
+
+namespace Crpg.Application.UTest.Clans.Commands;
+
+public class RewardClanItemCommandTest : TestBase
+{
+    [Test]
+    public async Task ReturnsErrorIfClanItemAlreadyAssigned()
+    {
+        var item = new Item { Id = "crpg_exclusive_helm_h1", Enabled = false };
+        var user = new User { Platform = Platform.Steam, PlatformUserId = "1", Name = "Leader" };
+        var clan = new Clan { Tag = "TST", Name = "Test Clan" };
+        var member = new ClanMember { User = user, Clan = clan, Role = ClanMemberRole.Leader };
+        var existingUserItem = new UserItem { User = user, Item = item, ClanItem = new ClanItem { Clan = clan } };
+
+        ArrangeDb.Items.Add(item);
+        ArrangeDb.Clans.Add(clan);
+        ArrangeDb.ClanMembers.Add(member);
+        ArrangeDb.UserItems.Add(existingUserItem);
+        await ArrangeDb.SaveChangesAsync();
+
+        var result = await Mediator.Send(new RewardClanItemCommand
+        {
+            ActorUserId = 99,
+            ClanId = clan.Id,
+            ItemId = item.Id,
+        });
+
+        Assert.That(result.Errors![0].Code, Is.EqualTo(ErrorCode.ClanItemAlreadyExist));
+    }
+
+    [Test]
+    public async Task ProvisionsCopyToEachCurrentMember()
+    {
+        var item = new Item { Id = "crpg_exclusive_helm_h1", Enabled = false };
+        var clan = new Clan { Tag = "TST", Name = "Test Clan" };
+        var u1 = new User { Platform = Platform.Steam, PlatformUserId = "1", Name = "Leader" };
+        var u2 = new User { Platform = Platform.Steam, PlatformUserId = "2", Name = "Member" };
+        clan.Members = new List<ClanMember>
+        {
+            new() { User = u1, Clan = clan, Role = ClanMemberRole.Leader },
+            new() { User = u2, Clan = clan, Role = ClanMemberRole.Member },
+        };
+
+        ArrangeDb.Items.Add(item);
+        ArrangeDb.Clans.Add(clan);
+        await ArrangeDb.SaveChangesAsync();
+
+        var result = await Mediator.Send(new RewardClanItemCommand
+        {
+            ActorUserId = 99,
+            ClanId = clan.Id,
+            ItemId = item.Id,
+        });
+
+        Assert.That(result.Errors, Is.Null);
+        var provisioned = ActDb.UserItems
+            .Where(ui => ui.ClanItem != null && ui.ClanItem.ClanId == clan.Id)
+            .ToList();
+        Assert.That(provisioned, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public async Task ClanItemIsRemovedOnLeaveClan()
+    {
+        var item = new Item { Id = "crpg_exclusive_helm_h1", Enabled = false };
+        var clan = new Clan { Tag = "TST", Name = "Test Clan" };
+        var leader = new User { Platform = Platform.Steam, PlatformUserId = "1", Name = "Leader" };
+        var leaver = new User { Platform = Platform.Steam, PlatformUserId = "2", Name = "Leaver" };
+
+        var leaderMember = new ClanMember { User = leader, Clan = clan, Role = ClanMemberRole.Leader };
+        var leaverMember = new ClanMember { User = leaver, Clan = clan, Role = ClanMemberRole.Member };
+
+        // Clan item already in leaver's inventory.
+        var clanUserItem = new UserItem { User = leaver, Item = item, ClanItem = new ClanItem { Clan = clan } };
+
+        ArrangeDb.Items.Add(item);
+        ArrangeDb.Clans.Add(clan);
+        ArrangeDb.ClanMembers.Add(leaderMember);
+        ArrangeDb.ClanMembers.Add(leaverMember);
+        ArrangeDb.UserItems.Add(clanUserItem);
+        await ArrangeDb.SaveChangesAsync();
+
+        // Leaver kicks themselves (same userId == kickedUserId triggers LeaveClan).
+        var result = await Mediator.Send(new KickClanMemberCommand
+        {
+            UserId = leaver.Id,
+            ClanId = clan.Id,
+            KickedUserId = leaver.Id,
+        });
+
+        Assert.That(result.Errors, Is.Null);
+
+        // The leaver's clan-exclusive UserItem and its ClanItem marker should be gone.
+        var remaining = ActDb.UserItems
+            .Where(ui => ui.UserId == leaver.Id && ui.ClanItem != null)
+            .ToList();
+        Assert.That(remaining, Is.Empty);
+    }
+}


### PR DESCRIPTION
**Forewarning:**  AI _SLOP_ used.

I need a professional to read this.  Please excuse any bad manners from my PR's as I am still learning protocol here, would definitely appreciate any nudges in the right direction.

Pretty self-explanatory, function is intended to allow clan-only items.  Told Claude to reference code that is used to give personal items to players and build with that structure.

If you are able to help me test this or test on your own, I am open to either it would be greatly appreciated.

> This would build on clan play and allow for further interactions within sub-communities- potentially pulling more players into a sense of belonging into their clans & even convince players without a home to reach out to clans of their interest.

> we could potentially get custom designed banners to run around with as well.

thank you.

V/r
ynyng