### PR TITLE
feat: cleave for infantry hitting mounted cavalry

### DIFF
--- a/src/Module.Server/HarmonyPatches/DecideWeaponCollisionReactionPatch.cs
+++ b/src/Module.Server/HarmonyPatches/DecideWeaponCollisionReactionPatch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
@@ -9,23 +9,41 @@ public class DecideWeaponCollisionReactionPatch
 {
     [HarmonyPostfix]
     [HarmonyPatch(typeof(MissionCombatMechanicsHelper), "DecideWeaponCollisionReaction")]
-    public static void AddAxeSlicedThrough(
+    public static void AddSlicedThrough(
         ref MeleeCollisionReaction colReaction,
         in Blow registeredBlow,
         in AttackCollisionData collisionData,
         Agent attacker,
-        Agent defender, in MissionWeapon attackerWeapon,
+        Agent defender,
+        in MissionWeapon attackerWeapon,
         bool isFatalHit,
         bool isShruggedOff,
         float momentumRemaining)
     {
-        // Check if the weapon used for the attack is an axe
+        // Bail early if already slicing through or the hit didn't connect to an agent body.
+        if (colReaction == MeleeCollisionReaction.SlicedThrough)
+        {
+            return;
+        }
+
+        bool hitEnemy = collisionData.IsColliderAgent && !collisionData.AttackBlockedWithShield;
+        if (!hitEnemy)
+        {
+            return;
+        }
+
+        // Original behaviour: all axes cleave regardless of target.
         var weaponClass = attackerWeapon.IsEmpty ? WeaponClass.Undefined : attackerWeapon.CurrentUsageItem.WeaponClass;
         bool isAxe = weaponClass == WeaponClass.OneHandedAxe || weaponClass == WeaponClass.TwoHandedAxe;
-        // Check if the attack hit an enemy (not a shield or an obstacle)
-        bool hitEnemy = collisionData.IsColliderAgent && !collisionData.AttackBlockedWithShield;
-        // Modify the collision reaction if the conditions are met
-        if (isAxe && hitEnemy && colReaction != MeleeCollisionReaction.SlicedThrough)
+
+        // New behaviour: any melee weapon cleaves when an infantry attacker hits a mounted defender.
+        // defender.MountAgent != null  → the hit target is a rider sitting on a horse.
+        // attacker.MountAgent == null  → the attacker is on foot (infantry).
+        bool attackerIsOnFoot = attacker?.MountAgent == null;
+        bool defenderIsMounted = defender?.MountAgent != null;
+        bool infantryHittingCav = attackerIsOnFoot && defenderIsMounted;
+
+        if (isAxe || infantryHittingCav)
         {
             colReaction = MeleeCollisionReaction.SlicedThrough;
         }


### PR DESCRIPTION
**Forewarning:**  AI _SLOP_ used.

Intention is to have all infantry, regardless of weapon type to cleave both cav and player on hit if applicable, unsure of the behavior this would cause.

> i did consider cav also allowing cleave against other cav but that would probably be not the best route, worth considering but im sure you can think of reasons as to why that wouldnt be the best idea

Please DM me @ynyng on discord if you are willing to help me set up a playable environment for testing, or if you are capable of hosting yourself I would love to schedule a time to test.  

Thank you.

V/r
ynyng