### PR TITLE
mod: Lower respec cost by 25% (lvl 30-38)

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -7,7 +7,7 @@
   "defaultExperienceMultiplier": 1.0,
   "experienceMultiplierByGeneration": 0.03,
   "maxExperienceMultiplierForGeneration": 1.48,
-  "respecializePriceForLevel30": 5000,
+  "respecializePriceForLevel30": 3750,
   "respecializePriceHalfLife": 24,
   "freeRespecializeIntervalDays": 7,
   "freeRespecializePostWindowHours": 12,


### PR DESCRIPTION
Lower respec cost by 25% between level 30 - 38

High levels were somewhat neutered in their strength, but respec costs were not properly adjusted to match. High levels currently feel the burn of a quite large respec cost, but given the power increase is much lower than what it was, respec cost logically should drop as well. This change lowers respec cost by 25% between levels 30 and 38 using the constant we have available to us (which enables an easy change)


Old static costs vs New static costs after lowered cost 
(degradation over time will still happen, so over the course of 7 days, cost will still lower)
L30: 5000 -> 3750
L31: 10000 -> 7500
L32: 20000 -> 15000
L33: 40000 -> 30000
L34: 80000 -> 60000
L35: 160000 -> 120000
L36: 320000 -> 240000
L37: 640000 -> 480000
L38: 1280000 -> 960000
