### PR TITLE
mod: Clamp weapon inaccuracy to range [0, 1] in CrpgAgentStatCalculat…

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -550,6 +550,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                     1.0f);
 
                 props.WeaponInaccuracy *= encumbranceMultiplier;
+                props.WeaponInaccuracy = MathF.Clamp(props.WeaponInaccuracy, 0f, 1f);
 
                 // Reload & draw speed penalty: linearly drops from 1.0 at 20 to 0.25 at 30
                 float reloadThrustMultiplier = totalEncumbrance <= 20f


### PR DESCRIPTION
Bug Description
When a character is mounted, heavily encumbered by armor, and has very low ranged proficiency and Mounted Archery, the final ranged WeaponInaccuracy value can become extremely large.

This can cause the crosshair to behave incorrectly. When zooming with Shift, the reticle may visually collapse inward instead of expanding normally, making the crosshair appear inverted or broken.

Root Cause
Mounted ranged inaccuracy stacks several penalties:

Low weapon proficiency increases the base ranged inaccuracy.
Low Mounted Archery applies a large mounted ranged penalty.
Heavy armor encumbrance applies an additional quadratic inaccuracy penalty.
In extreme cases, these penalties can push WeaponInaccuracy beyond the range expected by the client-side crosshair logic.

PR Explanation
This PR clamps the final mounted ranged WeaponInaccuracy value after both Mounted Archery and encumbrance penalties are applied.

The clamp is applied only inside the mounted ranged path, covering:

Throwing weapons
Bows
Crossbows
This prevents extreme low-skill, heavily encumbered mounted ranged builds from breaking the crosshair while preserving normal ranged behavior. Players with typical mounted ranged stats, such as 2-3 Mounted Archery and 150-180 weapon proficiency, should not be affected because their final inaccuracy values remain below the clamp threshold.