### PR TITLE
mod: Global reduction on quest rewards

### DIFF
--- a/data/quests.json
+++ b/data/quests.json
@@ -8,8 +8,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 1500,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -21,8 +21,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 750,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -34,8 +34,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 750,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -47,8 +47,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 750,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -60,8 +60,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 1000,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -73,8 +73,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 1250,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -86,8 +86,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 1250,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -99,8 +99,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 500,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -112,8 +112,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 20,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -125,8 +125,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 5,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -138,8 +138,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 15,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -151,8 +151,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 10,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -164,8 +164,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 80,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -177,8 +177,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 200,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -190,8 +190,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 500,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -203,8 +203,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 750,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -216,8 +216,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 500,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -229,8 +229,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 10,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -242,8 +242,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 30,
-    "rewardGold": 3000,
-    "rewardExperience": 100000,
+    "rewardGold": 500,
+    "rewardExperience": 25000,
     "isActive": true
   },
   {
@@ -255,8 +255,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 5000,
-    "rewardGold": 10000,
-    "rewardExperience": 350000,
+    "rewardGold": 5000,
+    "rewardExperience": 150000,
     "isActive": true
   },
   {
@@ -268,8 +268,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 100,
-    "rewardGold": 10000,
-    "rewardExperience": 350000,
+    "rewardGold": 5000,
+    "rewardExperience": 150000,
     "isActive": true
   },
   {
@@ -281,8 +281,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 25,
-    "rewardGold": 10000,
-    "rewardExperience": 350000,
+    "rewardGold": 5000,
+    "rewardExperience": 150000,
     "isActive": true
   },
   {
@@ -294,8 +294,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 50,
-    "rewardGold": 10000,
-    "rewardExperience": 350000,
+    "rewardGold": 5000,
+    "rewardExperience": 150000,
     "isActive": true
   },
   {
@@ -307,8 +307,8 @@
     "aggregationType": "Sum",
     "aggregationField": "Damage",
     "requiredValue": 5000,
-    "rewardGold": 10000,
-    "rewardExperience": 350000,
+    "rewardGold": 5000,
+    "rewardExperience": 150000,
     "isActive": true
   },
   {
@@ -320,8 +320,8 @@
     "aggregationType": "Count",
     "aggregationField": null,
     "requiredValue": 500,
-    "rewardGold": 10000,
-    "rewardExperience": 350000,
+    "rewardGold": 5000,
+    "rewardExperience": 150000,
     "isActive": true
   }
 ]


### PR DESCRIPTION
Globally reduce quest rewards

Reduces dailies from:
3,000 gold -> 500 gold
100,000 XP -> 25,000 XP

Reduces weeklies from:
10,000 gold -> 5,000 gold
350,000 XP -> 150,000 XP

Currently both types of rewards are offering too much output for too little overall input. With time we can likely create custom rewards for quests per individual quest, however for now the amount of output to effort ratio is too low and as a result the reward should match the level of effort required.