### PR TITLE
mod: Lower reroll cost to better fit with new reward from quests

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -86,5 +86,5 @@
   "marketplaceGoldFeePercent": 5,
   "questDailyQuestsPerUser": 3,
   "questWeeklyQuestsPerUser": 1,
-  "questRerollDailyQuestPrice": 300
+  "questRerollDailyQuestPrice": 150
 }


### PR DESCRIPTION
Lower cost of reroll to 150

Lowers the cost of a reroll from 300 > 150 - This change is being made to ensure users aren't near-immediately invalidating any reward potential

On the old reward function, a user could in theory reroll 30 times before completely invalidating their rewards, this was too high.
With reward lowered, as it stands a user can reroll (at cost of 300) a max of 5 times. This change pushes it into a fairer space and allows 10 rerolls (at a cost of 150) total before gold earnings from the quest are invalidated.