### PR TITLE
mod: Increase light crossbow reload movement speed

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -413,7 +413,7 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
                     props.ReloadSpeed *= ImpactOfStrReqOnCrossbows(agent, 0.15f, primaryItem);
 
                     // slow on reload (kicks in a bit late tho)
-                    props.BipedalRangedReloadSpeedMultiplier = 0.1f;
+                    props.BipedalRangedReloadSpeedMultiplier = 0.190f;
                 }
 
                 // Bows

--- a/src/Module.Server/MapRotation/ds_config_crpg_teamdeathmatch.txt
+++ b/src/Module.Server/MapRotation/ds_config_crpg_teamdeathmatch.txt
@@ -27,3 +27,5 @@ start_game
 set_automated_battle_count -1
 enable_automated_battle_switching
 crpg_apply_harmony_patches
+GamePassword yoyo
+crpg_frozen_bots True


### PR DESCRIPTION
Increase `BipedalRangedReloadSpeedMultiplier` for the light crossbow from `0.1` to `0.190`

The movespeed adjustment made to light xbow ended up being a bit too aggressive. As such this is being walked back (pun intended) for the purpose of fairer balance. Movement is still intentionally slow and at a walking pace, but will adjust further if needed.

Also update the TDM DS test configuration by adding a server password and enabling frozen bots by default to assist in future balance testing and are included alongside this balance adjustment for convenience.